### PR TITLE
Consolidate calibrated Île-de-France / Paris scenario for 5% sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 **1.0.0-dev**
 
+- Provide calibrated Île-de-France/Paris eqasim simulation for 5% sample
+- Make use of `isUrban` attribute from eqasim `1.0.6`
+- Update to eqasim `1.0.6`
 - Make GTFS date configurable
 - Use synpp 1.2.2 to fix Windows directory regeneration issue
 - Make pipeline configurable for other departments and regions, add documentation

--- a/data/spatial/departments.py
+++ b/data/spatial/departments.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+import os
+
+"""
+Provides the municipality zoning system.
+"""
+
+def configure(context):
+    context.stage("data.spatial.municipalities")
+
+def execute(context):
+    df_departements = context.stage("data.spatial.municipalities").dissolve(
+        by = "departement_id").drop(columns = ["commune_id", "has_iris"]).reset_index()
+
+    return df_departements

--- a/matsim/runtime/eqasim.py
+++ b/matsim/runtime/eqasim.py
@@ -10,7 +10,7 @@ def configure(context):
     context.stage("matsim.runtime.java")
     context.stage("matsim.runtime.maven")
 
-    context.config("eqasim_version", "1.0.5")
+    context.config("eqasim_version", "1.0.6")
 
 def run(context, command, arguments):
     version = context.config("eqasim_version")
@@ -29,7 +29,7 @@ def execute(context):
     # Clone repository and checkout version
     git.run(context, [
         "clone", "https://github.com/eqasim-org/eqasim-java.git",
-        "--branch", "paris-update", #"v%s" % version,
+        "--branch", "v%s" % version,
         "--single-branch", "eqasim-java",
         "--depth", "1"
     ])

--- a/matsim/runtime/eqasim.py
+++ b/matsim/runtime/eqasim.py
@@ -29,7 +29,7 @@ def execute(context):
     # Clone repository and checkout version
     git.run(context, [
         "clone", "https://github.com/eqasim-org/eqasim-java.git",
-        "--branch", "v%s" % version,
+        "--branch", "paris-update", #"v%s" % version,
         "--single-branch", "eqasim-java",
         "--depth", "1"
     ])

--- a/matsim/simulation/prepare.py
+++ b/matsim/simulation/prepare.py
@@ -14,6 +14,8 @@ def configure(context):
     context.stage("matsim.runtime.java")
     context.stage("matsim.runtime.eqasim")
 
+    context.stage("data.spatial.departments")
+
     context.config("sampling_rate")
     context.config("processes")
     context.config("random_seed")
@@ -84,6 +86,33 @@ def execute(context):
         "--output-path", "ile_de_france_config.xml"
     ])
     assert os.path.exists("%s/ile_de_france_config.xml" % context.path())
+
+    # Add urban attributes to population and network
+    df_shape = context.stage("data.spatial.departments")[["departement_id", "geometry"]].rename(
+        columns = dict(departement_id = "id")
+    )
+    df_shape["id"] = df_shape["id"].astype(str)
+    df_shape.to_file("%s/departments.shp" % context.path())
+
+    eqasim.run(context, "org.eqasim.core.scenario.spatial.RunImputeSpatialAttribute", [
+        "--input-population-path", "prepared_population.xml.gz",
+        "--output-population-path", "prepared_population.xml.gz",
+        "--input-network-path", "ile_de_france_network.xml.gz",
+        "--output-network-path", "ile_de_france_network.xml.gz",
+        "--shape-path", "departments.shp",
+        "--shape-attribute", "id",
+        "--shape-value", "75",
+        "--attribute", "isUrban"
+    ])
+
+    eqasim.run(context, "org.eqasim.core.scenario.spatial.RunAdjustCapacity", [
+        "--input-path", "ile_de_france_network.xml.gz",
+        "--output-path", "ile_de_france_network.xml.gz",
+        "--shape-path", "departments.shp",
+        "--shape-attribute", "id",
+        "--shape-value", "75",
+        "--factor", str(0.8)
+    ])
 
     # Route population
     eqasim.run(context, "org.eqasim.core.scenario.routing.RunPopulationRouting", [


### PR DESCRIPTION
This PR introduces changes that update the dependency on `eqasim:1.0.6` and introduce changes that lead to a calibrated 5% output of the Île-de-France / Paris scenario. 

This includes the following:
- Making use of new standard values (5% replanning rate for mode choice)
- Making use of new utility estimators and pricing structure for Île-de-France
- Adjusting the capacity of links inside of Paris to 80% of the initial value (as pipeline output)
- Adding the `isUrban` attribute to activities and links, which is used in utility estimation