### PR TITLE
Activity chains that do not start/end at home

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - java -version
   - mvn -version
   - osmosis -v
-  - pytest -s tests/
+  - travis_wait pytest tests/
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - java -version
   - mvn -version
   - osmosis -v
-  - travis_wait pytest tests/
+  - travis_wait 30 pytest tests/
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - java -version
   - mvn -version
   - osmosis -v
-  - pytest tests/
+  - pytest -s tests/
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Update to `eqasim-java:1.2.0` to support tails and "free" activity chains
 - Allow for activity chains that do not start and end at home
 - Improve handling of education attribute in ENTD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Allow for activity chains that do not start and end at home
 - Improve handling of education attribute in ENTD
 
 **1.1.0**

--- a/matsim/runtime/eqasim.py
+++ b/matsim/runtime/eqasim.py
@@ -10,8 +10,8 @@ def configure(context):
     context.stage("matsim.runtime.java")
     context.stage("matsim.runtime.maven")
 
-    context.config("eqasim_version", "1.1.0")
-    context.config("eqasim_branch", "v1.1.0")
+    context.config("eqasim_version", "1.2.0")
+    context.config("eqasim_branch", "v1.2.0")
     context.config("eqasim_repository", "https://github.com/eqasim-org/eqasim-java.git")
     context.config("eqasim_path", "")
 

--- a/synthesis/population/activities.py
+++ b/synthesis/population/activities.py
@@ -18,11 +18,6 @@ def execute(context):
     counts = df_activities.groupby("person_id").size().reset_index(name = "trip_count")["trip_count"].values
     df_activities["trip_count"] = np.hstack([[count] * count for count in counts])
 
-    # Make sure that days start and end at home. May be handled more flexible
-    # in the future.
-    assert not np.any(df_activities["is_first_trip"] & (df_activities["preceding_purpose"] != "home"))
-    assert not np.any(df_activities["is_last_trip"] & (df_activities["following_purpose"] != "home"))
-
     # Shift times and types of trips to arrive at activities
     df_activities["purpose"] = df_activities["preceding_purpose"]
     df_activities["end_time"] = df_activities["departure_time"]

--- a/synthesis/population/matched.py
+++ b/synthesis/population/matched.py
@@ -165,12 +165,6 @@ def execute(context):
 
     df_target = context.stage("synthesis.population.sampled")
 
-    # Filter for chains that start and end at home
-    f_invalid_start = df_source_trips["is_first_trip"] & (df_source_trips["preceding_purpose"] != "home")
-    f_invalid_end = df_source_trips["is_last_trip"] & (df_source_trips["following_purpose"] != "home")
-    invalid_person_ids = set(df_source_trips[f_invalid_start | f_invalid_end]["person_id"].unique())
-    df_source = df_source[~df_source["person_id"].isin(invalid_person_ids)]
-
     # Define matching attributes
     AGE_BOUNDARIES = [14, 29, 44, 59, 74, 1000]
     df_target["age_class"] = np.digitize(df_target["age"], AGE_BOUNDARIES, right = True)

--- a/synthesis/population/spatial/locations.py
+++ b/synthesis/population/spatial/locations.py
@@ -29,19 +29,21 @@ def execute(context):
     df_work_locations = df_locations[df_locations["purpose"] == "work"]
     df_work_locations = pd.merge(df_work_locations, df_work[["person_id", "location_id", "geometry"]], on = "person_id")
     df_work_locations = df_work_locations[["person_id", "activity_index", "location_id", "geometry"]]
+    assert not df_work_locations["geometry"].isna().any()
 
     # Education locations
     df_education_locations = df_locations[df_locations["purpose"] == "education"]
     df_education_locations = pd.merge(df_education_locations, df_education[["person_id", "location_id", "geometry"]], on = "person_id")
     df_education_locations = df_education_locations[["person_id", "activity_index", "location_id", "geometry"]]
+    assert not df_education_locations["geometry"].isna().any()
 
     # Secondary locations
     df_secondary_locations = df_locations[~df_locations["purpose"].isin(("home", "work", "education"))].copy()
-    df_secondary["activity_index"] = df_secondary["trip_index"] + 1
     df_secondary_locations = pd.merge(df_secondary_locations, df_secondary[[
         "person_id", "activity_index", "location_id", "geometry"
     ]], on = ["person_id", "activity_index"], how = "left")
     df_secondary_locations = df_secondary_locations[["person_id", "activity_index", "location_id", "geometry"]]
+    assert not df_secondary_locations["geometry"].isna().any()
 
     # Validation
     initial_count = len(df_locations)
@@ -52,6 +54,7 @@ def execute(context):
 
     assert initial_count == final_count
 
+    assert not df_locations["geometry"].isna().any()
     df_locations = gpd.GeoDataFrame(df_locations, crs = dict(init = "epsg:2154"))
 
     return df_locations

--- a/synthesis/population/spatial/primary/candidates.py
+++ b/synthesis/population/spatial/primary/candidates.py
@@ -101,8 +101,13 @@ def execute(context):
     df_persons = context.stage("synthesis.population.enriched")[["person_id", "household_id"]].copy()
     df_trips = context.stage("synthesis.population.trips")
 
-    df_persons["has_work_trip"] = df_persons["person_id"].isin(df_trips[df_trips["following_purpose"] == "work"]["person_id"])
-    df_persons["has_education_trip"] = df_persons["person_id"].isin(df_trips[df_trips["following_purpose"] == "education"]["person_id"])
+    df_persons["has_work_trip"] = df_persons["person_id"].isin(df_trips[
+        (df_trips["following_purpose"] == "work") | (df_trips["preceding_purpose"] == "work")
+    ]["person_id"])
+    
+    df_persons["has_education_trip"] = df_persons["person_id"].isin(df_trips[
+        (df_trips["following_purpose"] == "education") | (df_trips["preceding_purpose"] == "education")
+    ]["person_id"])
 
     df_homes = context.stage("synthesis.population.spatial.home.zones")
     df_persons = pd.merge(df_persons, df_homes, on = "household_id")

--- a/synthesis/population/spatial/secondary/components.py
+++ b/synthesis/population/spatial/secondary/components.py
@@ -10,7 +10,7 @@ class CustomDistanceSampler(rda.FeasibleDistanceSampler):
         self.distributions = distributions
 
     def sample_distances(self, problem):
-        distances = np.zeros((problem["size"] + 1))
+        distances = np.zeros((len(problem["modes"])))
 
         for index, (mode, travel_time) in enumerate(zip(problem["modes"], problem["travel_times"])):
             mode_distribution = self.distributions[mode]
@@ -24,7 +24,7 @@ class CustomDistanceSampler(rda.FeasibleDistanceSampler):
 
         return distances
 
-class CustomDiscretizationSolver(rda.DiscretizationSolver):
+class CandidateIndex:
     def __init__(self, data):
         self.data = data
         self.indices = {}
@@ -33,16 +33,47 @@ class CustomDiscretizationSolver(rda.DiscretizationSolver):
             print("Constructing spatial index for %s ..." % purpose)
             self.indices[purpose] = sklearn.neighbors.KDTree(data["locations"])
 
+    def query(self, purpose, location):
+        index = self.indices[purpose].query(location.reshape(1, -1), return_distance = False)[0][0]
+        identifier = self.data[purpose]["identifiers"][index]
+        location = self.data[purpose]["locations"][index]
+        return identifier, location
+
+    def sample(self, purpose, random):
+        index = random.randint(0, len(self.data[purpose]["locations"]))
+        identifier = self.data[purpose]["identifiers"][index]
+        location = self.data[purpose]["locations"][index]
+        return identifier, location
+
+class CustomDiscretizationSolver(rda.DiscretizationSolver):
+    def __init__(self, index):
+        self.index = index
+
     def solve(self, problem, locations):
         discretized_locations = []
         discretized_identifiers = []
 
         for location, purpose in zip(locations, problem["purposes"]):
-            index = self.indices[purpose].query(location.reshape(1, -1), return_distance = False)[0][0]
+            identifier, location = self.index.query(purpose, location.reshape(1, -1))
 
-            discretized_identifiers.append(self.data[purpose]["identifiers"][index])
-            discretized_locations.append(self.data[purpose]["locations"][index])
+            discretized_identifiers.append(identifier)
+            discretized_locations.append(location)
+
+        assert len(discretized_locations) == problem["size"]
 
         return dict(
             valid = True, locations = np.vstack(discretized_locations), identifiers = discretized_identifiers
         )
+
+class CustomFreeChainSolver(rda.RelaxationSolver):
+    def __init__(self, random, index):
+        self.random = random
+        self.index = index
+
+    def solve(self, problem, distances):
+        identifier, anchor = self.index.sample(problem["purposes"][0], self.random)
+        locations = rda.sample_tail(self.random, anchor, distances)
+        locations = np.vstack((anchor, locations))
+
+        assert len(locations) == len(distances) + 1
+        return dict(valid = True, locations = locations)

--- a/synthesis/population/spatial/secondary/locations.py
+++ b/synthesis/population/spatial/secondary/locations.py
@@ -67,8 +67,8 @@ def resample_distributions(distributions, factors):
         for distribution in mode_distributions["distributions"]:
             distribution["cdf"] = resample_cdf(distribution["cdf"], factors[mode])
 
-from synthesis.population.spatial.secondary.rda import AssignmentSolver, DiscretizationErrorObjective, GravityChainSolver
-from synthesis.population.spatial.secondary.components import CustomDistanceSampler, CustomDiscretizationSolver
+from synthesis.population.spatial.secondary.rda import AssignmentSolver, DiscretizationErrorObjective, GravityChainSolver, AngularTailSolver, GeneralRelaxationSolver
+from synthesis.population.spatial.secondary.components import CustomDistanceSampler, CustomDiscretizationSolver, CandidateIndex, CustomFreeChainSolver
 
 def execute(context):
     # Load trips and primary locations
@@ -117,7 +117,7 @@ def execute(context):
                 df_locations.append(df_locations_item)
                 df_convergence.append(df_convergence_item)
 
-    df_locations = pd.concat(df_locations).sort_values(by = ["person_id", "trip_index"])
+    df_locations = pd.concat(df_locations).sort_values(by = ["person_id", "activity_index"])
     df_convergence = pd.concat(df_convergence)
 
     print("Success rate:", df_convergence["valid"].mean())
@@ -130,6 +130,11 @@ def process(context, arguments):
   # Set up RNG
   random = np.random.RandomState(context.config("random_seed"))
 
+  # Set up discretization solver
+  destinations = context.data("destinations")
+  candidate_index = CandidateIndex(destinations)
+  discretization_solver = CustomDiscretizationSolver(candidate_index)
+
   # Set up distance sampler
   distance_distributions = context.data("distance_distributions")
   distance_sampler = CustomDistanceSampler(
@@ -138,13 +143,14 @@ def process(context, arguments):
         distributions = distance_distributions)
 
   # Set up relaxation solver; currently, we do not consider tail problems.
-  relaxation_solver = GravityChainSolver(
+  chain_solver = GravityChainSolver(
     random = random, eps = 10.0, lateral_deviation = 10.0, alpha = 0.1
     )
 
-  # Set up discretization solver
-  destinations = context.data("destinations")
-  discretization_solver = CustomDiscretizationSolver(destinations)
+  tail_solver = AngularTailSolver(random = random)
+  free_solver = CustomFreeChainSolver(random, candidate_index)
+
+  relaxation_solver = GeneralRelaxationSolver(chain_solver, tail_solver, free_solver)
 
   # Set up assignment solver
   thresholds = dict(
@@ -169,11 +175,11 @@ def process(context, arguments):
   for problem in find_assignment_problems(df_trips, df_primary):
       result = assignment_solver.solve(problem)
 
-      starting_trip_index = problem["trip_index"]
+      starting_activity_index = problem["activity_index"]
 
       for index, (identifier, location) in enumerate(zip(result["discretization"]["identifiers"], result["discretization"]["locations"])):
           df_locations.append((
-              problem["person_id"], starting_trip_index + index, identifier, geo.Point(location)
+              problem["person_id"], starting_activity_index + index, identifier, geo.Point(location)
           ))
 
       df_convergence.append((
@@ -184,8 +190,9 @@ def process(context, arguments):
           last_person_id = problem["person_id"]
           context.progress.update()
 
-  df_locations = pd.DataFrame.from_records(df_locations, columns = ["person_id", "trip_index", "location_id", "geometry"])
+  df_locations = pd.DataFrame.from_records(df_locations, columns = ["person_id", "activity_index", "location_id", "geometry"])
   df_locations = gpd.GeoDataFrame(df_locations, crs = dict(init = "epsg:2154"))
+  assert not df_locations["geometry"].isna().any()
 
   df_convergence = pd.DataFrame.from_records(df_convergence, columns = ["valid", "size"])
   return df_locations, df_convergence

--- a/synthesis/population/spatial/secondary/problems.py
+++ b/synthesis/population/spatial/secondary/problems.py
@@ -58,7 +58,7 @@ def find_assignment_problems(df, df_locations):
             problem["purposes"] = problem["purposes"][:-1]
 
         else:
-            raise RuntimeError("The presented 'problem' is neither a chain nor a tail")
+            pass # Neither chain nor tail
 
         # Define size
         problem["size"] = len(problem["purposes"])
@@ -81,5 +81,10 @@ def find_assignment_problems(df, df_locations):
         if destination_purpose in FIXED_PURPOSES:
             problem["destination"] = current_location[LOCATION_FIELDS.index(destination_purpose)] # Shapely POINT
             problem["destination"] = np.array([[problem["destination"].x, problem["destination"].y]])
+
+        if problem["origin"] is None:
+            problem["activity_index"] = problem["trip_index"]
+        else:
+            problem["activity_index"] = problem["trip_index"] + 1
 
         yield problem


### PR DESCRIPTION
- [x] Make sure pipeline can properly do this in secondary location assignment and elsewhere
- [x] Make sure that tails are handled properly (secondary activities before or after the first / last primary one)
- [x] Make sure that "free" chains are handled properly (chains without any primary activities)
- [x] Make new `eqasim-java` version with respective functionality and update version

The idea would be that the "tails" or the complete "free chains" are handled as tours.