### PR TITLE
Add a basic sample based vehicle fleet generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Add a basic sample based vehicle fleet generation tailored for use with the `emissions` matsim contrib
 - Fixing socioprofessional category for Nantes and Lyon (Cerema)
 - Fix documentation and processing for Nantes GTFS
 - Add law status of the SIRENE enterprises for down-stream freight models (this requires both SIREN and SIRET data as input!)

--- a/config.yml
+++ b/config.yml
@@ -27,3 +27,10 @@ config:
 
   # Only interesting if you run the simulation
   java_memory: 14G
+
+
+  # uncomment below to enable vehicle fleet generation
+  
+  # generate_vehicles_file: True
+  # generate_vehicles_method: fleet_sample
+  # vehicles_data_year: 2015

--- a/data/vehicles/raw.py
+++ b/data/vehicles/raw.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+
+"""
+This stage loads the raw data of the specified vehicle fleet data
+https://www.statistiques.developpement-durable.gouv.fr/donnees-sur-le-parc-automobile-francais-au-1er-janvier-2021
+"""
+
+def configure(context):
+    context.config("data_path")
+    context.config("vehicles_data_year", 2015)
+    context.stage("data.spatial.codes")
+
+def execute(context):
+
+    year = context.config("vehicles_data_year")
+
+    df_codes = context.stage("data.spatial.codes")
+
+    df_vehicle_com_counts = pd.read_excel(
+        "%s/vehicles_%s/Parc_VP_Communes_%s.xlsx" % (context.config("data_path"), year, year)
+    )
+    df_vehicle_reg_counts = pd.read_excel(
+        "%s/vehicles_%s/Parc_VP_Regions_%s.xlsx" % (context.config("data_path"), year, year)
+    )
+    df_vehicle_com_counts["region_id"] = df_vehicle_com_counts["Code région"].astype("category")
+    df_vehicle_com_counts["departement_id"] = df_vehicle_com_counts["Code départment"].astype("category")
+    df_vehicle_com_counts["commune_id"] = df_vehicle_com_counts["Code commune"].astype("category")
+
+    df_vehicle_reg_counts["region_id"] = df_vehicle_reg_counts["Code région"].astype("category")
+
+    requested_departements = set(df_codes["departement_id"].unique())
+    requested_regions = set(df_codes["region_id"].astype(str).unique())
+
+    if len(requested_departements) > 0:
+        df_vehicle_com_counts = df_vehicle_com_counts[df_vehicle_com_counts["departement_id"].isin(requested_departements)]
+
+    if len(requested_regions) > 0:
+        df_vehicle_reg_counts = df_vehicle_reg_counts[df_vehicle_reg_counts["region_id"].isin(requested_regions)]
+
+    df_vehicle_com_counts["region_id"] = df_vehicle_com_counts["region_id"].cat.remove_unused_categories()
+    df_vehicle_com_counts["departement_id"] = df_vehicle_com_counts["departement_id"].cat.remove_unused_categories()
+    df_vehicle_com_counts["commune_id"] = df_vehicle_com_counts["commune_id"].cat.remove_unused_categories()
+
+    df_vehicle_reg_counts["region_id"] = df_vehicle_reg_counts["region_id"].cat.remove_unused_categories()
+
+    df_vehicle_com_counts["critair"] = df_vehicle_com_counts["Vignette Crit'air"]
+    df_vehicle_com_counts["technology"] = df_vehicle_com_counts["Energie"]
+
+    df_vehicle_reg_counts["critair"] = df_vehicle_reg_counts["Vignette crit'air"]
+    df_vehicle_reg_counts["technology"] = df_vehicle_reg_counts["Energie"]
+
+    count_column_name = "Parc au 01/01/%s" % context.config("vehicles_data_year")
+    age_column_name = "Age au 01/01/%s" % context.config("vehicles_data_year")
+
+    df_vehicle_com_counts["fleet"] = df_vehicle_com_counts[count_column_name]
+    df_vehicle_reg_counts["fleet"] = df_vehicle_reg_counts[count_column_name]
+    df_vehicle_reg_counts["age"] = df_vehicle_reg_counts[age_column_name]
+
+    df_vehicle_fleet_counts = df_vehicle_com_counts.groupby(["region_id", "commune_id", "critair","technology"])["fleet"].sum().reset_index().dropna()
+    df_vehicle_age_counts = df_vehicle_reg_counts.groupby(["region_id", "critair", "technology", "age"])["fleet"].sum().reset_index().dropna()
+
+    return df_vehicle_fleet_counts, df_vehicle_age_counts

--- a/data/vehicles/types.py
+++ b/data/vehicles/types.py
@@ -1,0 +1,242 @@
+import pandas as pd
+
+"""
+This stage creates the various type of vehicles needed for the simulation with HBEFA emissions
+"""
+
+HBEFA_TECH = ['petrol', 'diesel']
+HBEFA_EURO = ['1', '2', '3', '4', '5', '6ab', '6c', '6d']
+
+def configure(context):
+    pass
+
+def execute(context):
+
+    vehicle_types = [
+        {
+            'type_id': 'default_car', 'nb_seats': 4, 'length': 5.0, 'width': 1.0, 'pce': 1.0, 'mode': "car",
+            'hbefa_cat': "PASSENGER_CAR", 'hbefa_tech': "average", 'hbefa_size': "average", 'hbefa_emission': "average",
+        }
+    ]
+
+    for technology in HBEFA_TECH:
+        for euro in HBEFA_EURO:
+            tech = technology
+
+            id = "car_%s_%s" % (technology, euro)
+
+            if technology == "diesel" and euro in ['2', '3']:
+                euro += " (DPF)"
+
+            size = ">=2L" if technology == "petrol" else "<1,4L"
+
+            if technology == "petrol":
+                tech += " (4S)"
+
+            emission = "PC %s Euro-%s" % (tech, euro)
+
+            vehicle_types.append({
+                'type_id': id, 'length': 7.5, 'width': 1.0,
+                'hbefa_cat': "PASSENGER_CAR", 'hbefa_tech': tech, 'hbefa_size': size, 'hbefa_emission': emission,
+            })
+
+    df_types = pd.DataFrame.from_records(vehicle_types)
+    return df_types
+
+
+"""
+<vehicleType id="PC petrol Euro-1">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-1</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC petrol Euro-2">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-2</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC petrol Euro-3">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-3</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC petrol Euro-4">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-4</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC petrol Euro-5">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-5</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC petrol Euro-6ab">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-6ab</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC petrol Euro-6c">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-6c</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+
+	<vehicleType id="PC petrol Euro-6d">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">petrol (4S)</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&gt;=2L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC petrol Euro-6d</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC diesel Euro-1">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">diesel</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&lt;1,4L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC diesel Euro-1</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC diesel Euro-2 (DPF)">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">diesel</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&lt;1,4L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC diesel Euro-2 (DPF)</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC diesel Euro-3 (DPF)">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">diesel</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&lt;1,4L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC diesel Euro-3 (DPF)</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC diesel Euro-4">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">diesel</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&lt;1,4L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC diesel Euro-4</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC diesel Euro-5">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">diesel</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&lt;1,4L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC diesel Euro-5</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC diesel Euro-6ab">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">diesel</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&lt;1,4L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC diesel Euro-6ab</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+	
+	<vehicleType id="PC diesel Euro-6c">
+		<length meter="7.5"/>
+		<width meter="1.0"/>
+		<engineInformation>
+			<attributes>
+				<attribute name="HbefaVehicleCategory" class="java.lang.String">PASSENGER_CAR</attribute>
+				<attribute name="HbefaTechnology" class="java.lang.String">diesel</attribute>
+				<attribute name="HbefaSizeClass" class="java.lang.String">&lt;1,4L</attribute>
+				<attribute name="HbefaEmissionsConcept" class="java.lang.String">PC diesel Euro-6c</attribute>
+			</attributes>
+		</engineInformation>
+	</vehicleType>
+"""

--- a/matsim/output.py
+++ b/matsim/output.py
@@ -8,6 +8,7 @@ def configure(context):
     context.config("output_path")
     context.config("output_prefix", "ile_de_france_")
     context.config("write_jar", True)
+    context.config("generate_vehicles_file", False)
 
     context.stage("documentation.meta_output")
 
@@ -17,7 +18,7 @@ def execute(context):
         context.stage("matsim.simulation.prepare")
     )
 
-    for name in [
+    file_names = [
         "%shouseholds.xml.gz" % context.config("output_prefix"),
         "%spopulation.xml.gz" % context.config("output_prefix"),
         "%sfacilities.xml.gz" % context.config("output_prefix"),
@@ -25,7 +26,12 @@ def execute(context):
         "%stransit_schedule.xml.gz" % context.config("output_prefix"),
         "%stransit_vehicles.xml.gz" % context.config("output_prefix"),
         "%sconfig.xml" % context.config("output_prefix")
-    ]:
+    ]
+
+    if context.config("generate_vehicles_file"):
+        file_names.append("%svehicles.xml.gz" % context.config("output_prefix"))
+
+    for name in file_names:
         shutil.copy(
             "%s/%s" % (context.path("matsim.simulation.prepare"), name),
             "%s/%s" % (context.config("output_path"), name)

--- a/matsim/scenario/vehicles.py
+++ b/matsim/scenario/vehicles.py
@@ -1,0 +1,56 @@
+import io, gzip
+
+import numpy as np
+import pandas as pd
+
+import matsim.writers as writers
+
+def configure(context):
+    context.stage("synthesis.vehicles.selected")
+
+TYPE_FIELDS = ["type_id", "nb_seats", "length", "width", "pce", "mode"]
+VEHICLE_FIELDS = ["vehicle_id", "type_id", "critair", "technology", "age", "euro"]
+
+def execute(context):
+    output_path = "%s/vehicles.xml.gz" % context.path()
+
+    df_vehicle_types, df_vehicles = context.stage("synthesis.vehicles.selected")
+
+    with gzip.open(output_path, 'wb+') as writer:
+        with io.BufferedWriter(writer, buffer_size = 2 * 1024**3) as writer:
+            writer = writers.VehiclesWriter(writer)
+            writer.start_vehicles()
+
+            with context.progress(total = len(df_vehicle_types), label = "Writing vehicles types ...") as progress:
+                for type in df_vehicle_types.to_dict(orient="records"):
+                    writer.add_type(
+                        type["type_id"],
+                        length=type["length"],
+                        width=type["width"],
+                        engine_attributes = {
+                            "HbefaVehicleCategory": type["hbefa_cat"],
+                            "HbefaTechnology": type["hbefa_tech"],
+                            "HbefaSizeClass": type["hbefa_size"],
+                            "HbefaEmissionsConcept": type["hbefa_emission"]
+                        }
+                    )
+                    progress.update()
+
+            with context.progress(total = len(df_vehicles), label = "Writing vehicles ...") as progress:
+                for vehicle in df_vehicles.to_dict(orient="records"):
+
+                    writer.add_vehicle(
+                        vehicle["vehicle_id"],
+                        vehicle["type_id"],
+                        attributes = {
+                            "critair": vehicle["critair"],
+                            "technology": vehicle["technology"],
+                            "age": vehicle["age"],
+                            "euro": vehicle["euro"]
+                        }
+                    )
+                    progress.update()
+
+            writer.end_vehicles()
+
+    return "vehicles.xml.gz"

--- a/matsim/simulation/prepare.py
+++ b/matsim/simulation/prepare.py
@@ -7,6 +7,9 @@ def configure(context):
     context.stage("matsim.scenario.population")
     context.stage("matsim.scenario.households")
 
+    if context.config("generate_vehicles_file", False):
+        context.stage("matsim.scenario.vehicles")
+
     context.stage("matsim.scenario.facilities")
     context.stage("matsim.scenario.supply.processed")
     context.stage("matsim.scenario.supply.gtfs")
@@ -72,6 +75,13 @@ def execute(context):
         context.stage("matsim.scenario.supply.gtfs")["vehicles_path"]
     )
     shutil.copy(transit_vehicles_path, "%s/%stransit_vehicles.xml.gz" % (context.cache_path, context.config("output_prefix")))
+
+    if context.config("generate_vehicles_file"):
+        vehicles_path = "%s/%s" % (
+            context.path("matsim.scenario.vehicles"),
+            context.stage("matsim.scenario.vehicles")
+        )
+        shutil.copy(vehicles_path, "%s/%svehicles.xml.gz" % (context.cache_path, context.config("output_prefix")))
 
     # Generate base configuration
     eqasim.run(context, "org.eqasim.core.scenario.config.RunGenerateConfig", [

--- a/synthesis/output.py
+++ b/synthesis/output.py
@@ -9,6 +9,9 @@ def configure(context):
     context.stage("synthesis.population.activities")
     context.stage("synthesis.population.trips")
 
+    if context.config("generate_vehicles_file", False):
+        context.stage("synthesis.vehicles.selected")
+
     context.stage("synthesis.population.spatial.locations")
 
     context.stage("documentation.meta_output")
@@ -95,6 +98,13 @@ def execute(context):
     ]]
 
     df_trips.to_csv("%s/%strips.csv" % (output_path, output_prefix), sep = ";", index = None)
+
+    if context.config("generate_vehicles_file"):
+        # Prepare vehicles
+        df_vehicle_types, df_vehicles = context.stage("synthesis.vehicles.selected")
+
+        df_vehicle_types.to_csv("%s/%svehicle_types.csv" % (output_path, output_prefix), sep = ";", index = None)
+        df_vehicles.to_csv("%s/%svehicles.csv" % (output_path, output_prefix), sep = ";", index = None)
 
     # Prepare spatial data sets
     df_locations = context.stage("synthesis.population.spatial.locations")[[

--- a/synthesis/vehicles/fleet_sample/vehicles.py
+++ b/synthesis/vehicles/fleet_sample/vehicles.py
@@ -1,0 +1,138 @@
+import re
+import pandas as pd
+import numpy as np
+from datetime import date
+
+"""
+Creates the synthetic vehicle fleet
+"""
+
+def configure(context):
+    context.stage("synthesis.population.enriched")
+    context.stage("synthesis.population.spatial.home.zones")
+    context.stage("data.vehicles.raw")
+    context.stage("data.vehicles.types")
+
+    context.config("vehicles_data_year", 2015)
+
+def _sample_vehicle(context, args):
+    vehicle = args
+    year = context.config("vehicles_data_year")
+    df_vehicle_fleet_counts, df_vehicle_age_counts = context.data("fleet"), context.data("age")
+
+    commune_id = vehicle["commune_id"]
+
+    if  commune_id in df_vehicle_fleet_counts["commune_id"].unique():
+        fleet = df_vehicle_fleet_counts.loc[df_vehicle_fleet_counts["commune_id"] == commune_id]
+        choice = fleet.sample(weights="fleet")
+        critair = choice["critair"].values[0]
+        technology = choice["technology"].values[0]
+
+        age_mask = (df_vehicle_age_counts["critair"] == critair) & (df_vehicle_age_counts["technology"] == technology)
+        age = df_vehicle_age_counts.loc[age_mask].sample(weights="fleet")["age"].values[0]
+    else:
+        choice = df_vehicle_age_counts.sample(weights="fleet")
+        critair = choice["critair"].values[0]
+        technology = choice["technology"].values[0]
+        age = choice["age"].values[0]
+
+    vehicle["critair"] = critair
+    vehicle["technology"] = technology
+    vehicle["age"] = age
+
+    euro = _get_euro_from_critair(vehicle, year)
+    vehicle["euro"] = euro
+
+    if technology == "Gazole":
+        hbefa_tech = "diesel"
+        vehicle["type_id"] = "car_%s_%s" % (hbefa_tech, euro)
+    if technology == "Essence":
+        hbefa_tech = "petrol"
+        vehicle["type_id"] = "car_%s_%s" % (hbefa_tech, euro)
+
+    context.progress.update()
+    return vehicle
+
+def _get_euro_from_critair(vehicle, year):
+
+    critair = vehicle["critair"]  # Crit'air 1, Crit'air 2, ..., Crit'air 5, Crit'air E, Non classée
+    technology = vehicle["technology"]  # Gazole, Essence, Electrique et hydrogène, Essence hybride rechargeable, Gaz, Gazole hybride rechargeable
+    age = vehicle["age"]  # 0 ans, 1 ans, ..., 19 ans, >20 ans
+
+    # we are using the following table : https://www.ecologie.gouv.fr/sites/default/files/Tableau_classification_des_vehicules.pdf
+    age_num = re.findall(r'\d+', age)
+    if len(age_num) == 0:
+        raise RuntimeError("Badly formatted 'age' variable found for vehicle (id: %s) : %s" % (age, vehicle["vehicle_id"]))
+
+    birthday = int(year) - int(age_num[0])
+
+    euro = 1
+
+    # set minimum value based on birthday
+    if 1997 <= birthday < 2001:
+        euro = 2
+    if 2001 <= birthday < 2006:
+        euro = 3
+    if 2006 <= birthday < 2011:
+        euro = 4
+    if 2011 <= birthday < 2016:
+        euro = 5
+    if birthday >= 2016:
+        euro = 6
+
+    # refine based on critair
+    if critair == "Crit'air E" or technology == "Electrique et hydrogène":
+        euro = max(euro, 6)
+    if critair == "Crit'air 1" and (technology == "Gaz" or "hybride" in technology):
+        euro = max(euro, 6)
+    if critair == "Crit'air 1" and technology == "Essence":
+        euro = max(euro, 5)  # or 6 in table
+    if critair == "Crit'air 2" and technology == "Essence":
+        euro = max(euro, 4)
+    if critair == "Crit'air 2" and technology == "Gazole":
+        euro = max(euro, 5)  # or 6 in table
+    if critair == "Crit'air 3" and technology == "Essence":
+        euro = max(euro, 2) # or 3 in table
+    if critair == "Crit'air 3" and technology == "Gazole":
+        euro = max(euro, 4)
+    if critair == "Crit'air 4" and technology == "Gazole":
+        euro = max(euro, 3)
+    if critair == "Crit'air 5" and technology == "Gazole":
+        euro = max(euro, 2)
+    if critair == "Non classée" and technology == "Gazole":
+        euro = max(euro, 1)
+
+    euro = str(euro)
+    if euro == '6':
+        if 2016 <= birthday < 2019:
+            euro = '6ab'
+        else:
+            euro = '6c'
+
+    return euro
+
+def execute(context):
+
+    df_vehicle_types = context.stage("data.vehicles.types")
+
+    df_persons = context.stage("synthesis.population.enriched")
+    df_homes = context.stage("synthesis.population.spatial.home.zones")
+
+    df_vehicles = pd.merge(df_persons[["household_id", "person_id"]], df_homes[["household_id", "commune_id"]], on = "household_id")
+
+    df_vehicles = df_vehicles.rename(columns = { "person_id": "vehicle_id" })
+    df_vehicles = df_vehicles.drop_duplicates("vehicle_id")
+    df_vehicles["type_id"] = "default_car"
+
+    df_vehicle_fleet_counts, df_vehicle_age_counts = context.stage("data.vehicles.raw")
+
+    res = []
+
+    with context.progress(label = "Processing vehicles data ...", total = len(df_vehicles)) as progress:
+        with context.parallel(dict(fleet = df_vehicle_fleet_counts, age = df_vehicle_age_counts)) as parallel:
+            for df_partial in parallel.imap(_sample_vehicle, df_vehicles.to_dict(orient="records")):
+                res.append(df_partial)
+
+    df_vehicles = pd.DataFrame.from_dict(res)
+
+    return df_vehicle_types, df_vehicles

--- a/synthesis/vehicles/selected.py
+++ b/synthesis/vehicles/selected.py
@@ -1,0 +1,11 @@
+
+def configure(context):
+    method = context.config("generate_vehicles_method")
+
+    if method == "fleet_sample":
+        context.stage("synthesis.vehicles.fleet_sample.vehicles", alias = "vehicles")
+    else:
+        raise RuntimeError("Unknown vehicles generation method : %s" % method)
+
+def execute(context):
+    return context.stage("vehicles")


### PR DESCRIPTION
Add a basic sample based vehicle fleet generation tailored for use with the `emissions` matsim contrib

This is a basic sample approach based on the "Crit'Air" dataset available here : https://www.statistiques.developpement-durable.gouv.fr/donnees-sur-le-parc-automobile-francais-au-1er-janvier-2021

The algorithme is the following : 
 - foreach agent, create a vehicle with a `crit'air` value and a (engine) `technology` value using his/her `commune_id` fleet distribution
 - knowing the vehicle crit'air and technology, sample the vehicle `age` in the using the `region_id` distribution.
 - from the `age` and `crit'air` values the vehicle, determine the `euro` category

I'm using this successfully with the emissions contrib with HBEFA 4.2. 

Suggestions, remarks, "you should not have done this it's horrible", etc... are welcome !😄  