### PR TITLE
fix: Arbitrary order of week days in merged GTFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Fix: Arbitrary order of week days in merged GTFS
 - Use BPE 2021 instead of BPE 2019
 - Update configuration files for Lyon, Nantes, Corsica
 - Add a basic sample based vehicle fleet generation tailored for use with the `emissions` matsim contrib

--- a/data/gtfs/cleaned.py
+++ b/data/gtfs/cleaned.py
@@ -32,6 +32,14 @@ def execute(context):
     # Merge feeds
     merged_feed = gtfs.merge_feeds(feeds) if len(feeds) > 1 else feeds[0]
 
+    # Fix for pt2matsim (will be fixed after PR #173)
+    # Order of week days must be fixed
+    days = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+    columns = list(merged_feed["calendar"].columns)
+    for day in days: columns.remove(day)
+    columns += ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+    merged_feed["calendar"] = merged_feed["calendar"][columns]
+
     # Write feed (not as a ZIP, but as files, for pt2matsim)
     gtfs.write_feed(merged_feed, "%s/output" % context.path())
 


### PR DESCRIPTION
The merged GTFS had an arbitrary order of weekdays (but pt2matsim expects ordered values from monday to sunday, see https://github.com/matsim-org/pt2matsim/pull/173). This bug only shows up if one selects explicitly one day from GTFS using `gtfs_date: 20220901` in the configuration. By default the day with most services is selected.