### PR TITLE
fix: Fix coordinates format (commas vs points) in BPE.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Fix: Handle commas in coordinates in BPE
 - Fix: Properly treat non-movers in EDGT 44
 - Fix: Avoid duplicate persons in same households
 - Add option to export detailed link geometries

--- a/data/bpe/cleaned.py
+++ b/data/bpe/cleaned.py
@@ -59,8 +59,8 @@ def execute(context):
     df["activity_type"] = df["activity_type"].astype("category")
 
     # Clean coordinates
-    df["x"] = df["LAMBERT_X"].astype(np.float)
-    df["y"] = df["LAMBERT_Y"].astype(np.float)
+    df["x"] = df["LAMBERT_X"].str.replace(",", ".").astype(np.float)
+    df["y"] = df["LAMBERT_Y"].str.replace(",", ".").astype(np.float)
 
     # Clean IRIS and commune
     df["iris_id"] = df["DCIRIS"].str.replace("_", "")

--- a/data/bpe/cleaned.py
+++ b/data/bpe/cleaned.py
@@ -59,8 +59,8 @@ def execute(context):
     df["activity_type"] = df["activity_type"].astype("category")
 
     # Clean coordinates
-    df["x"] = df["LAMBERT_X"].str.replace(",", ".").astype(np.float)
-    df["y"] = df["LAMBERT_Y"].str.replace(",", ".").astype(np.float)
+    df["x"] = df["LAMBERT_X"].astype(str).str.replace(",", ".").astype(np.float)
+    df["y"] = df["LAMBERT_Y"].astype(str).str.replace(",", ".").astype(np.float)
 
     # Clean IRIS and commune
     df["iris_id"] = df["DCIRIS"].str.replace("_", "")


### PR DESCRIPTION
In BPE 2021, some numbers have a comma ("`,`"). These break the pipeline when the lines where the commas are, are considered. For example, when you try to synthesize a population for Île-de-France.

Here is an example of trace when this is not fixed:

```
Traceback (most recent call last):
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/synpp/__main__.py", line 14, in <module>
    synpp.run_from_yaml(config_path)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/synpp/pipeline.py", line 803, in run_from_yaml
    run(definitions=definitions, config=config, working_directory=working_directory, flowchart_path=flowchart_path, dryrun=dryrun)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/synpp/pipeline.py", line 713, in run
    result = stage["wrapper"].execute(context)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/synpp/pipeline.py", line 59, in execute
    return self.instance.execute(context)
  File "/mnt/Data/these/carpooling_potential/population_synthesis/data/bpe/cleaned.py", line 62, in execute
    df["x"] = df["LAMBERT_X"].astype(np.float)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/pandas/core/generic.py", line 5698, in astype
    new_data = self._data.astype(dtype=dtype, copy=copy, errors=errors)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/pandas/core/internals/managers.py", line 582, in astype
    return self.apply("astype", dtype=dtype, copy=copy, errors=errors)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/pandas/core/internals/managers.py", line 442, in apply
    applied = getattr(b, f)(**kwargs)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/pandas/core/internals/blocks.py", line 625, in astype
    values = astype_nansafe(vals1d, dtype, copy=True)
  File "/home/aina/anaconda3/envs/population_synthesis/lib/python3.7/site-packages/pandas/core/dtypes/cast.py", line 897, in astype_nansafe
    return arr.astype(dtype, copy=True)
ValueError: could not convert string to float: '650961,76'
```