### PR TITLE
fix: Fix raw mode recognition in ENTD.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Fix: Make types consistent for mode recognition in ENTD
 - Fix: Properly treat non-movers in EDGT 44
 - Fix: Avoid duplicate persons in same households
 - Add option to export detailed link geometries

--- a/data/hts/entd/raw.py
+++ b/data/hts/entd/raw.py
@@ -68,7 +68,7 @@ def execute(context):
     df_deploc = pd.read_csv(
         "%s/entd_2008/K_deploc.csv" % context.config("data_path"),
         sep = ";", encoding = "latin1", usecols = K_DEPLOC_COLUMNS,
-        dtype = { "DEP": str }
+        dtype = { "DEP": str, "V2_MTP": str }
     )
 
     return df_individu, df_tcm_individu, df_menage, df_tcm_menage, df_deploc


### PR DESCRIPTION
I noticed that the ENTD cleaning stage does not recognize the bike mode. So I fixed that by forcing the `str` type on the mode column in the reading stage.

### Explanation
The read of the ENTD consists of a reading stage (_data/hts/entd/raw.py_) and a cleaning stage (_data/hts/entd/cleaned.py_).

The reading stage uses the pandas' method `read_csv`. If not supplied, this method guesses the column types.
In particular, the column `V2_MTP` become of _float_. That means that all the trailing zeros are ignored.

This behavior becomes an issue when we expect these trailing zeros to stay when we cast it to the _string_ type.
In particular, here:
https://github.com/eqasim-org/ile-de-france/blob/0aac9f3699b19ff8be7e264b722ddbb1d229d236/data/hts/entd/cleaned.py#L180
We expect the bike mode to be "2.20"  :
https://github.com/eqasim-org/ile-de-france/blob/0aac9f3699b19ff8be7e264b722ddbb1d229d236/data/hts/entd/cleaned.py#L31

The problem is that in `df_trips`, all the "2.20" have already been transformed to "2.2".

When generating a population for Île-de-France, it represents 1349 lines.

### Another solution

We could also change the mode bike to "2.2", but the preceding solution tries to stay consistent with [the official variable dictionary of ENTD](http://www.progedo-adisp.fr/documents/lil-0634/lil-0634dcod.pdf).