### PR TITLE
feat: Add more configurable paths for input data.

### DIFF
--- a/data/income/municipality.py
+++ b/data/income/municipality.py
@@ -14,13 +14,16 @@ Loads and prepares income distributions by municipality:
 def configure(context):
     context.config("data_path")
     context.stage("data.spatial.municipalities")
+    context.config("income_com_path", "filosofi_2015/FILO_DISP_COM.xls")
+    context.config("income_year", 15)
 
 def execute(context):
     # Load income distribution
+    year = str(context.config("income_year"))
     df = pd.read_excel(
-        "%s/filosofi_2015/FILO_DISP_COM.xls" % context.config("data_path"),
+        "%s/%s" % (context.config("data_path"), context.config("income_com_path")),
         sheet_name = "ENSEMBLE", skiprows = 5
-    )[["CODGEO"] + ["D%d15" % q if q != 5 else "Q215" for q in range(1, 10)]]
+    )[["CODGEO"] + [("D%d" % q) + year if q != 5 else "Q2" + year for q in range(1, 10)]]
     df.columns = ["commune_id", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9"]
     df["reference_median"] = df["q5"].values
 
@@ -82,7 +85,7 @@ def execute(context):
     return df[["commune_id", "q1", "q2", "q3", "q4", "q5", "q6", "q7", "q8", "q9", "is_imputed", "is_missing", "reference_median"]]
 
 def validate(context):
-    if not os.path.exists("%s/filosofi_2015/FILO_DISP_COM.xls" % context.config("data_path")):
+    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("income_com_path"))):
         raise RuntimeError("Filosofi data is not available")
 
-    return os.path.getsize("%s/filosofi_2015/FILO_DISP_COM.xls" % context.config("data_path"))
+    return os.path.getsize("%s/%s" % (context.config("data_path"), context.config("income_com_path")))

--- a/data/income/region.py
+++ b/data/income/region.py
@@ -8,21 +8,26 @@ Loads the regional aggregated income distribution.
 
 def configure(context):
     context.config("data_path")
+    context.config("income_reg_path", "filosofi_2015/FILO_DISP_REG.xls")
+    context.config("income_year", 15)
 
 def execute(context):
     df = pd.read_excel(
-        "%s/filosofi_2015/FILO_DISP_REG.xls" % context.config("data_path"),
+        "%s/%s" % (context.config("data_path"), context.config("income_reg_path")),
         sheet_name = "ENSEMBLE", skiprows = 5
     )
 
-    values = df[df["CODGEO"] == 11][[
-        "D115", "D215", "D315", "D415", "Q215", "D615", "D715", "D815", "D915"
-    ]].values[0]
+    values = df[df["CODGEO"] == 11][
+        [
+            i + str(context.config("income_year"))
+            for i in ["D1", "D2", "D3", "D4", "Q2", "D6", "D7", "D8", "D9"]
+        ]
+    ].values[0]
 
     return values
 
 def validate(context):
-    if not os.path.exists("%s/filosofi_2015/FILO_DISP_REG.xls" % context.config("data_path")):
+    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("income_reg_path"))):
         raise RuntimeError("Filosofi data is not available")
 
-    return os.path.getsize("%s/filosofi_2015/FILO_DISP_REG.xls" % context.config("data_path"))
+    return os.path.getsize("%s/%s" % (context.config("data_path"), context.config("income_reg_path")))

--- a/data/od/raw.py
+++ b/data/od/raw.py
@@ -11,6 +11,8 @@ Loads raw OD data from French census data.
 def configure(context):
     context.stage("data.spatial.codes")
     context.config("data_path")
+    context.config("od_pro_path", "rp_2015/FD_MOBPRO_2015.dbf")
+    context.config("od_sco_path", "rp_2015/FD_MOBSCO_2015.dbf")
 
 def execute(context):
     df_codes = context.stage("data.spatial.codes")
@@ -18,7 +20,7 @@ def execute(context):
 
     # First, load work
 
-    table = simpledbf.Dbf5("%s/rp_2015/FD_MOBPRO_2015.dbf" % context.config("data_path"))
+    table = simpledbf.Dbf5("%s/%s" % (context.config("data_path"), context.config("od_pro_path")))
     records = []
 
     with context.progress(label = "Reading work flows ...", total = table.numrec) as progress:
@@ -39,7 +41,7 @@ def execute(context):
 
     # Second, load education
 
-    table = simpledbf.Dbf5("%s/rp_2015/FD_MOBSCO_2015.dbf" % context.config("data_path"))
+    table = simpledbf.Dbf5("%s/%s" % (context.config("data_path"), context.config("od_sco_path")))
     records = []
 
     with context.progress(label = "Reading education flows ...", total = 4782736) as progress:
@@ -59,13 +61,13 @@ def execute(context):
     pd.concat(records).to_hdf("%s/education.hdf" % context.cache_path, "movements")
 
 def validate(context):
-    if not os.path.exists("%s/rp_2015/FD_MOBPRO_2015.dbf" % context.config("data_path")):
+    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("od_pro_path"))):
         raise RuntimeError("RP MOBPRO data is not available")
 
-    if not os.path.exists("%s/rp_2015/FD_MOBSCO_2015.dbf" % context.config("data_path")):
+    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("od_sco_path"))):
         raise RuntimeError("RP MOBSCO data is not available")
 
     return [
-        os.path.getsize("%s/rp_2015/FD_MOBPRO_2015.dbf" % context.config("data_path")),
-        os.path.getsize("%s/rp_2015/FD_MOBSCO_2015.dbf" % context.config("data_path"))
+        os.path.getsize("%s/%s" % (context.config("data_path"), context.config("od_pro_path"))),
+        os.path.getsize("%s/%s" % (context.config("data_path"), context.config("od_sco_path")))
     ]

--- a/data/spatial/codes.py
+++ b/data/spatial/codes.py
@@ -8,19 +8,17 @@ they can be translated into each other. These are mainly IRIS, commune,
 departement and région.
 """
 
-YEAR = 2017
-SOURCE = "codes_%d/reference_IRIS_geo%d.xls" % (YEAR, YEAR)
-
 def configure(context):
     context.config("data_path")
 
     context.config("regions", [11])
     context.config("departments", [])
+    context.config("codes_path", "codes_2017/reference_IRIS_geo2017.xls")
 
 def execute(context):
     # Load IRIS registry
     df_codes = pd.read_excel(
-        "%s/%s" % (context.config("data_path"), SOURCE),
+        "%s/%s" % (context.config("data_path"), context.config("codes_path")),
         skiprows = 5, sheet_name = "Emboitements_IRIS"
     )[["CODE_IRIS", "DEPCOM", "DEP", "REG"]].rename(columns = {
         "CODE_IRIS": "iris_id",
@@ -51,7 +49,7 @@ def execute(context):
     return df_codes
 
 def validate(context):
-    if not os.path.exists("%s/%s" % (context.config("data_path"), SOURCE)):
+    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("codes_path"))):
         raise RuntimeError("Spatial reference codes are not available")
 
-    return os.path.getsize("%s/%s" % (context.config("data_path"), SOURCE))
+    return os.path.getsize("%s/%s" % (context.config("data_path"), context.config("codes_path")))

--- a/data/spatial/iris.py
+++ b/data/spatial/iris.py
@@ -7,17 +7,15 @@ import os
 Loads the IRIS zoning system.
 """
 
-YEAR = 2017
-SOURCE = "iris_%d/CONTOURS-IRIS.shp" % YEAR
-
 def configure(context):
     context.config("data_path")
+    context.config("iris_path", "iris_2017/CONTOURS-IRIS.shp")
     context.stage("data.spatial.codes")
 
 def execute(context):
     df_codes = context.stage("data.spatial.codes")
 
-    df_iris = gpd.read_file("%s/%s" % (context.config("data_path"), SOURCE))[[
+    df_iris = gpd.read_file("%s/%s" % (context.config("data_path"), context.config("iris_path")))[[
         "CODE_IRIS", "INSEE_COM", "geometry"
     ]].rename(columns = {
         "CODE_IRIS": "iris_id",
@@ -41,7 +39,7 @@ def execute(context):
     return df_iris
 
 def validate(context):
-    if not os.path.exists("%s/%s" % (context.config("data_path"), SOURCE)):
+    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("iris_path"))):
         raise RuntimeError("IRIS data is not available")
 
-    return os.path.getsize("%s/%s" % (context.config("data_path"), SOURCE))
+    return os.path.getsize("%s/%s" % (context.config("data_path"), context.config("iris_path")))

--- a/data/spatial/population.py
+++ b/data/spatial/population.py
@@ -6,20 +6,20 @@ import os
 Loads aggregate population data.
 """
 
-YEAR = 2015
-SOURCE = "rp_%d/base-ic-evol-struct-pop-%d.xls" % (YEAR, YEAR)
-
 def configure(context):
     context.config("data_path")
     context.stage("data.spatial.codes")
+    context.config("population_path", "rp_2015/base-ic-evol-struct-pop-2015.xls")
+    context.config("population_year", 15)
 
 def execute(context):
+    year = str(context.config("population_year"))
     df_population = pd.read_excel(
-        "%s/%s" % (context.config("data_path"), SOURCE),
-        skiprows = 5, sheet_name = "IRIS", usecols = ["IRIS", "COM", "DEP", "REG", "P15_POP"]
+        "%s/%s" % (context.config("data_path"), context.config("population_path")),
+        skiprows = 5, sheet_name = "IRIS", usecols = ["IRIS", "COM", "DEP", "REG", "P%s_POP" % year]
     ).rename(columns = {
         "IRIS": "iris_id", "COM": "commune_id", "DEP": "departement_id", "REG": "region_id",
-        "P15_POP": "population"
+        "P%s_POP" % year: "population"
     })
 
     df_population["iris_id"] = df_population["iris_id"].astype("category")
@@ -40,7 +40,7 @@ def execute(context):
     return df_population[["region_id", "departement_id", "commune_id", "iris_id", "population"]]
 
 def validate(context):
-    if not os.path.exists("%s/%s" % (context.config("data_path"), SOURCE)):
+    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("population_path"))):
         raise RuntimeError("Aggregated census data is not available")
 
-    return os.path.getsize("%s/%s" % (context.config("data_path"), SOURCE))
+    return os.path.getsize("%s/%s" % (context.config("data_path"), context.config("population_path")))


### PR DESCRIPTION
To make the code more usable as it is and to progress in line with the generalization of the pipeline (https://github.com/eqasim-org/ile-de-france/issues/139), I suggest adding the parameters below. It should also simplify the update of the input files.
- `income_com_path` (default: `filosofi_2015/FILO_DISP_COM.xls`),
- `income_reg_path` (default : `filosofi_2015/FILO_DISP_REG.xls`),
- `income_year` because the income year is needed to parse the column names in FiLoSoFi data (default: `15`),
- `od_pro_path` (default: `rp_2015/FD_MOBPRO_2015.dbf`),
- `od_sco_path` (default: `rp_2015/FD_MOBSCO_2015.dbf`),
- `codes_path` (default: `codes_2017/reference_IRIS_geo2017.xls`),
- `iris_path` (default: `codes_2017/reference_IRIS_geo2017.xls`),
- `population_path` (default: `rp_2015/base-ic-evol-struct-pop-2015.xls`).

The name of the parameters and the default values are personal suggestions. We can discuss them if you want.