### PR TITLE
fix: Correct treatment of non-movers in CEREMA EDGT for Lyon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Fix: Correctly treat non-movers in CEREMA EDGT for Lyon
 - Configure directory for GTFS and then auto-detect contained zip files
 - Added integration tests for Windows
 - Updated conda environment based entirely on *conda-forge*

--- a/data/hts/edgt_lyon/cleaned_cerema.py
+++ b/data/hts/edgt_lyon/cleaned_cerema.py
@@ -115,6 +115,14 @@ def execute(context):
     # Has subscription
     df_persons["has_pt_subscription"] = df_persons["P10"].isin(["1", "2", "3"])
 
+    # Survey respondents 
+    # PENQ 1 : fully awnsered the travel questionary section, having a chain or non-movers
+    # PENQ 2 : nonrespondent of travel questionary section
+    df_persons["PENQ"] = df_persons["PENQ"].fillna("2").astype(int)
+    df_persons.loc[df_persons["PENQ"] == 1, "travel_respondent"] = True
+    df_persons.loc[df_persons["PENQ"] == 2, "travel_respondent"] = False
+    assert np.count_nonzero(df_persons["travel_respondent"].isna()) == 0
+
     # Trip purpose
     df_trips["following_purpose"] = "invalid"
     df_trips["preceding_purpose"] = "invalid"
@@ -162,7 +170,14 @@ def execute(context):
 
     # Chain length
     df_count = df_trips[["person_id"]].groupby("person_id").size().reset_index(name = "number_of_trips")
+
+    # People with at least one trip (number_of_trips > 0)
     df_persons = pd.merge(df_persons, df_count, on = "person_id", how = "left")
+    
+    # People that awnsered the travel questionary section but stayed at home (number_of_trips = 0)
+    df_persons.loc[df_persons["travel_respondent"] & df_persons["number_of_trips"].isna(), "number_of_trips"] = 0
+
+    # Nonrespondent of travel questionary section (number_of_trips = -1)
     df_persons["number_of_trips"] = df_persons["number_of_trips"].fillna(-1).astype(int)
 
     # Passenger attribute

--- a/data/hts/edgt_lyon/raw_cerema.py
+++ b/data/hts/edgt_lyon/raw_cerema.py
@@ -19,7 +19,7 @@ HOUSEHOLD_COLUMNS = {
 }
 
 PERSON_COLUMNS = {
-    "ECH": str, "PER": int, "PP2": str,
+    "ECH": str, "PER": int, "PP2": str, "PENQ": str,
     "P3": int, "P2": int, "P4": int,
     "P7": str, "P12": str,
     "P10": str, "P9": str, "P5": str,


### PR DESCRIPTION
Twin PR for #169 taking into account persons that have responded to the travel survey but stayed at home.