### PR TITLE
feat: load BD-TOPO by department

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Increase reproducibility for BD-TOPO by requiring user to dump the IGN files in 7z'ed GPKG format into one central folder for `bdtopo22`
 - Fix: Properly treat non-movers in EDGT Lyon ADISP data
 - Configure directory for GTFS and then auto-detect contained zip files
 - Added integration tests for Windows

--- a/config_corsica.yml
+++ b/config_corsica.yml
@@ -30,7 +30,6 @@ config:
   java_memory: 14G
 
   # Corsica settings
-  bdtopo_path: bdtopo_corsica
   regions: [94]
   gtfs_path: gtfs_corsica
   osm_path: osm/corse-latest.osm.pbf

--- a/config_lyon.yml
+++ b/config_lyon.yml
@@ -30,8 +30,7 @@ config:
   java_memory: 14G
 
   # Lyon settings
-  bdtopo_path: bdtopo_lyon
   regions: []
-  departments: ["01", 38, 42, 69, 69M]
+  departments: ["01", "38", "42", "69"]
   gtfs_path: gtfs_lyon
   osm_path: osm_lyon

--- a/config_nantes.yml
+++ b/config_nantes.yml
@@ -30,7 +30,6 @@ config:
   java_memory: 14G
 
   # Nantes settings
-  bdtopo_path: bdtopo_nantes
   regions: []
   departments: [44]
   gtfs_path: gtfs_nantes

--- a/config_toulouse.yml
+++ b/config_toulouse.yml
@@ -30,8 +30,7 @@ config:
   java_memory: 14G
 
   # Toulouse settings
-  bdtopo_path: bdtopo_toulouse
   regions: []
-  departments: ["09", 82, 81, 11, 31, 32] # 12 30 34 46 48 65 66
+  departments: ["09", "82", "81", "11", "31", "32"] # 12 30 34 46 48 65 66
   gtfs_path: gtfs_toulouse
   osm_path: osm_toulouse

--- a/data/bdtopo/output.py
+++ b/data/bdtopo/output.py
@@ -1,0 +1,14 @@
+import geopandas as gpd
+
+def configure(context):
+    context.config("output_path")
+    context.config("output_prefix", "ile_de_france_")
+
+    context.stage("data.bdtopo.raw")
+
+def execute(context):
+    df_buildings = context.stage("data.bdtopo.raw")
+
+    df_buildings.to_file("%s/%sbuildings.gpkg" % (
+        context.config("output_path"), context.config("output_prefix")
+    ))

--- a/data/bdtopo/raw.py
+++ b/data/bdtopo/raw.py
@@ -14,46 +14,110 @@ This stage loads the raw data from the French building registry.
 
 def configure(context):
     context.config("data_path")
-    context.config("bdtopo_path", "bdtopo_idf")
+    context.config("bdtopo_path", "bdtopo22")
+    context.config("bdtopo_date", "2022-03-15")
 
     context.stage("data.spatial.departments")
 
+def get_department_string(department_id):
+    department_id = str(department_id)
+
+    if len(department_id) == 2:
+        return "0{}".format(department_id)
+    elif len(department_id) == 3:
+        return department_id
+    else:
+        raise RuntimeError("Department identifier should have at least two characters")
+
 def execute(context):
     df_departments = context.stage("data.spatial.departments")
+    print("Expecting data for {} departments".format(len(df_departments)))
+    
+    candidate_paths = find_bdtopo("{}/{}".format(context.config("data_path"), context.config("bdtopo_path")))
+    department_paths = {}
+
+    date = context.config("bdtopo_date")
+
+    for department_id in df_departments["departement_id"].values:
+        for path in candidate_paths:
+            if path.endswith("BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D{}_{}.7z".format(
+                get_department_string(department_id), date)):
+                department_paths[department_id] = path
+                break
+    
+    for department_id in df_departments["departement_id"].values:
+        if department_id not in department_paths:        
+            raise RuntimeError("No BDTOPO data found for department {}".format(department_id))
+
     df_bdtopo = []
+    known_ids = set()
 
-    source_path = find_bdtopo("{}/{}".format(context.config("data_path"), context.config("bdtopo_path")))
+    for department_id, department_path in department_paths.items():
+        print("Loading department {}".format(department_id))
 
-    with py7zr.SevenZipFile(source_path) as archive:
-        building_paths = [
-            path for path in archive.getnames()
-            if re.search(r"/BATIMENT\.[a-z]{3}$", path)
-        ]
+        with py7zr.SevenZipFile(department_path) as archive:
+            # Find the path inside the archive
+            geometry_path = [path for path in archive.getnames() if path.endswith(".gpkg")]
+            
+            if len(geometry_path) != 1:
+                raise RuntimeError("Cannot find unambiguous geometry source in: {}".format(department_path))
 
-        archive.extract(context.path(), building_paths)
+            print("  Extracting ...")
+            archive.extract(context.path(), geometry_path[0])
 
-    shp_path = [path for path in building_paths if path.endswith(".shp")]
+            geometry_path = "{}/{}".format(context.path(), geometry_path[0])
 
-    if len(shp_path) != 1:
-        raise RuntimeError("Cannot find buildings inside the archive, please report this as an error!")
+        with context.progress(label = "Reading ...") as progress:
+            data = { "cleabs": [], "nombre_de_logements": [], "geometry": [] }
+            with fiona.open(geometry_path, layer = "batiment") as package:
+                for item in package:
+                    data["cleabs"].append(item["properties"]["cleabs"])
+                    data["nombre_de_logements"].append(item["properties"]["nombre_de_logements"])
+                    data["geometry"].append(geo.shape(item["geometry"]))
+                    progress.update()
 
-    with context.progress(label = "Loading BD TOPO residential buildings registry ...") as progress:
-        with fiona.open("{}/{}".format(context.path(), shp_path[0])) as archive:
-            for item in archive:
-                # we check for every buildings if it has residential use (only or mix use)
-                if item['properties']["NB_LOGTS"] is not None and int(item['properties']["NB_LOGTS"]) > 0:
-                    poly = geo.Polygon([i for i in item["geometry"]["coordinates"][0]])
+            df_buildings = pd.DataFrame(data)
+            df_buildings = gpd.GeoDataFrame(df_buildings, crs = "EPSG:2154")
+        
+        df_buildings["building_id"] = df_buildings["cleabs"].apply(lambda x: int(x[8:]))
+        df_buildings["housing"] = df_buildings["nombre_de_logements"].fillna(0).astype(int)
 
-                    if np.any(df_departments.covers(poly)):         
-                        df_bdtopo.append(dict(geometry = geo.Point(poly.centroid),
-                                              bdtopo_id = item["properties"]["ID"],
-                                              housing = int(item['properties']["NB_LOGTS"])))
+        df_buildings["centroid"] = df_buildings["geometry"].centroid
+        df_buildings = df_buildings.set_geometry("centroid")
 
-                progress.update()
+        print("  Filtering ...")
 
-    df_bdtopo = pd.DataFrame.from_records(df_bdtopo)
-    df_bdtopo = gpd.GeoDataFrame(df_bdtopo, crs = "EPSG:2154")
-    return df_bdtopo
+        initial_count = len(df_buildings)
+        df_buildings = df_buildings[df_buildings["housing"] > 0]
+        final_count = len(df_buildings)
+        print("    {}/{} filtered by dwellings".format(initial_count - final_count, initial_count))
+
+        initial_count = len(df_buildings)
+        df_buildings = df_buildings[~df_buildings["building_id"].isin(known_ids)]
+        final_count = len(df_buildings)
+        print("    {}/{} filtered duplicates".format(initial_count - final_count, initial_count))
+
+        initial_count = len(df_buildings)
+        df_buildings = gpd.sjoin(df_buildings, df_departments[
+            df_departments["departement_id"] == department_id
+        ], predicate = "within")
+        final_count = len(df_buildings)
+        print("    {}/{} filtered spatially".format(initial_count - final_count, initial_count))
+
+        df_buildings["department_id"] = department_id
+        df_buildings = df_buildings.set_geometry("geometry")
+
+        df_bdtopo.append(df_buildings[["building_id", "housing", "department_id", "geometry"]])
+        known_ids |= set(df_buildings["building_id"].unique())
+
+        os.remove(geometry_path)
+
+    df_bdtopo = pd.concat(df_bdtopo)
+
+    for department_id in df_departments["departement_id"].values:
+        assert np.count_nonzero(df_bdtopo["department_id"] == department_id) > 0
+
+    return df_bdtopo[["building_id", "housing", "geometry"]]
 
 def find_bdtopo(path):
     candidates = list(glob.glob("{}/*.7z".format(path)))
@@ -61,11 +125,8 @@ def find_bdtopo(path):
     if len(candidates) == 0:
         raise RuntimeError("BD TOPO data is not available in {}".format(path))
     
-    if len(candidates) > 1:
-        raise RuntimeError("Multiple candidates for BD TOPO are available in {}".format(path))
-    
-    return candidates[0]
+    return candidates
 
 def validate(context):
-    path = find_bdtopo("{}/{}".format(context.config("data_path"), context.config("bdtopo_path")))
-    return os.path.getsize(path)
+    paths = find_bdtopo("{}/{}".format(context.config("data_path"), context.config("bdtopo_path")))
+    return sum([os.path.getsize(path) for path in paths])

--- a/docs/cases/corsica.md
+++ b/docs/cases/corsica.md
@@ -14,10 +14,11 @@ simulation for **Corsica**.
 You need to download the region-specific buildings database.
 
 - [Buildings database](https://geoservices.ign.fr/bdtopo)
-- Click on the right link *BD TOPO® Shapefile Régions* 
-- It will leads you to *BD TOPO® some date Tous Thèmes par région format shapefile projection légale*
-- Download *Région Corse - R 94*
-- Copy the *7z* file into `data/bdtopo_corsica`.
+- In the sidebar on the right, under *Téléchargement anciennes éditions*, click on *BD TOPO® 2022 GeoPackage Départements* to go to the saved data publications from 2022.
+- The data is split by department and they are identified with a number. For Corsica, download:
+  - Corse-du-Sud (2A)
+  - Haute-Corse (2B)
+- Copy the two *7z* files into `data/bdtopo22`.
 
 ### B) OpenStreetMap data
 
@@ -42,7 +43,8 @@ Download all the *zip*'d GTFS schedules and put them into the folder `data/gtfs_
 
 Afterwards, you should have the following additional files in your directory structure:
 
-- `data/bdtopo_corsica/BDTOPO_3-3_TOUSTHEMES_SHP_LAMB93_R94_2022-12-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D02A_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D02B_2022-03-15.7z`
 
 *Only for simulation:*
 
@@ -56,19 +58,8 @@ updated continuously.
 
 ## Generating the population
 
-To generate the synthetic population, the `config.yml` needs to be updated. While
-the relevant code points to the Île-de-France data sets by default, you can
-adjust the paths inidividually. To let the pipeline use the *Zone E* census
-data set and the updated buildings, add the following to `config.yml` in the `config` section:
-
-```yaml
-config:
-  # ...
-  bdtopo_path: bdtopo_corsica
-  # ...
-```
-
-Furthermore, by default the pipeline will filter all other data sets for the
+To generate the synthetic population, the `config.yml` needs to be updated. 
+By default the pipeline will filter all other data sets for the
 Île-de-France region. To make it use the selected region, adjust the
 configuration as follows:
 

--- a/docs/cases/lyon.md
+++ b/docs/cases/lyon.md
@@ -14,10 +14,14 @@ simulation for **Lyon** and surroundings.
 You need to download the region-specific buildings database.
 
 - [Buildings database](https://geoservices.ign.fr/bdtopo)
-- Click on the right link *BD TOPO® Shapefile Régions* 
-- It will leads you to *BD TOPO® some date Tous Thèmes par région format shapefile projection légale*
-- Download *Région Auvergne-Rhône-Alpes - R 84*
-- Copy the *7z* file into `data/bdtopo_lyon`.
+- In the sidebar on the right, under *Téléchargement anciennes éditions*, click on *BD TOPO® 2022 GeoPackage Départements* to go to the saved data publications from 2022.
+- The data is split by department and they are identified with a number. For the departments around Lyon, download:
+  - Ain (01)
+  - Isère (38)
+  - Loire (42)
+  - Rhône (69)
+- Copy the four *7z* files into `data/bdtopo22`.
+- If you decide to add additional departments to the simulation (for instance, to simulate the whole Auvergne-Rhône-Alpes region) make sure to download the respective data sets.
 
 ### B) OpenStreetMap data
 
@@ -88,7 +92,10 @@ If you get the EDGT data from the ADISP portal, the following files should be pr
 
 Afterwards, you should have the following additional files in your directory structure:
 
-- `data/bdtopo_lyon/BDTOPO_3-3_TOUSTHEMES_SHP_LAMB93_R84_2022-12-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D001_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D038_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D042_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D069_2022-03-15.7z`
 - Plus the files from the EDGT if you want / can use them in `data/edgt_lyon_2015`
 
 *Only for simulation:*
@@ -109,19 +116,8 @@ updated continuously.
 
 ## Generating the population
 
-To generate the synthetic population, the `config.yml` needs to be updated. While
-the relevant code points to the Île-de-France data sets by default, you can
-adjust the paths inidividually. To let the pipeline use the *Zone E* census
-data set and the updated buildings, add the following to `config.yml` in the `config` section:
-
-```yaml
-config:
-  # ...
-  bdtopo_path: bdtopo_lyon
-  # ...
-```
-
-Furthermore, by default the pipeline will filter all other data sets for the
+To generate the synthetic population, the `config.yml` needs to be updated. 
+By default the pipeline will filter all other data sets for the
 Île-de-France region. To make it use the selected region, adjust the
 configuration as follows:
 
@@ -129,14 +125,14 @@ configuration as follows:
 config:
   # ...
   regions: []
-  departments: ["01", 38, 42, 69, 69M] # 26 "07"
+  departments: ["01", "38", "42", "69"] # 26 "07"
   # ...
 ```
 
 This will make the pipeline filter all data sets for the departments noted
 in the list above, which is a set of the closest departments around Lyon.
 If you want to generate the whole (ancient) Rhône-Alpes region, add the commented out
-department identifiers to the list.
+department identifiers to the list (and make sure to download the buildings database)
 
 In case you want to *optionally* use the regional HTS (otherwise the national ENTD)
 is used, choose the updated HTS in the config file.

--- a/docs/cases/nantes.md
+++ b/docs/cases/nantes.md
@@ -5,7 +5,7 @@ for other regions than Île-de-France. In any case, we recommend to first
 follow instructions to set up a [synthetic population for Île-de-France](../population.md)
 and (if desired) the [respective simulation](../simulation.md). The following
 describes the steps and additional data sets necessary to create a population and
-simulation for **Nantes** and its surrounding department Loire Atlantique.
+simulation for **Nantes** and its surrounding department Loire-Atlantique.
 
 ## Additional data
 
@@ -14,10 +14,10 @@ simulation for **Nantes** and its surrounding department Loire Atlantique.
 You need to download the region-specific buildings database.
 
 - [Buildings database](https://geoservices.ign.fr/bdtopo)
-- Click on the right link *BD TOPO® Shapefile Régions* 
-- It will leads you to *BD TOPO® some date Tous Thèmes par région format shapefile projection légale*
-- Download *Région Pays de la Loire - R 52*
-- Copy the *7z* file into `data/bdtopo_nantes`.
+- In the sidebar on the right, under *Téléchargement anciennes éditions*, click on *BD TOPO® 2022 GeoPackage Départements* to go to the saved data publications from 2022.
+- The data is split by department and they are identified with a number. For the Loire-Atlantique department around Nantes, download:
+  - Loire-Atlantique (44)
+- Copy the *7z* file into `data/bdtopo22`.
 
 ### B) OpenStreetMap data
 
@@ -58,7 +58,7 @@ should be present:
 
 Afterwards, you should have the following additional files in your directory structure:
 
-- `data/bdtopo_nantes/BDTOPO_3-3_TOUSTHEMES_SHP_LAMB93_R52_2022-12-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D044_2022-03-15.7z`
 - Plus the files from the EDGT if you want / can use them in `data/edgt_44_2015`
 
 *Only for simulation:*
@@ -79,19 +79,8 @@ updated continuously.
 
 ## Generating the population
 
-To generate the synthetic population, the `config.yml` needs to be updated. While
-the relevant code points to the Île-de-France data sets by default, you can
-adjust the paths inidividually. To let the pipeline use the *Zone C* census
-data set and the updated buildings, add the following to `config.yml` in the `config` section:
-
-```yaml
-config:
-  # ...
-  bdtopo_path: bdtopo_nantes
-  # ...
-```
-
-Furthermore, by default the pipeline will filter all other data sets for the
+To generate the synthetic population, the `config.yml` needs to be updated.
+By default the pipeline will filter all other data sets for the
 Île-de-France region. To make it use the selected region, adjust the
 configuration as follows:
 

--- a/docs/cases/toulouse.md
+++ b/docs/cases/toulouse.md
@@ -14,10 +14,16 @@ simulation for **Toulouse**.
 You need to download the region-specific buildings database.
 
 - [Buildings database](https://geoservices.ign.fr/bdtopo)
-- Click on the right link *BD TOPO® Shapefile Régions* 
-- It will leads you to *BD TOPO® some date Tous Thèmes par région format shapefile projection légale*
-- Download *Région Occitanie - R 76*
-- Copy the *7z* file into `data/bdtopo_toulouse`.
+- In the sidebar on the right, under *Téléchargement anciennes éditions*, click on *BD TOPO® 2022 GeoPackage Départements* to go to the saved data publications from 2022.
+- The data is split by department and they are identified with a number. For the departments around Toulouse, download:
+  - Ariège (09)
+  - Aude (11)
+  - Haute-Garonne (31)
+  - Gers (32)
+  - Tarn (81)
+  - Var (82)
+- Copy the six *7z* files into `data/bdtopo22`.
+- If you decide to add additional departments to the simulation (for instance, to simulate the whole Occitanie region) make sure to download the respective data sets.
 
 ### B) OpenStreetMap data
 
@@ -47,7 +53,12 @@ Download all the *zip*'d GTFS schedules and put them into the folder `data/gtfs_
 
 Afterwards, you should have the following additional files in your directory structure:
 
-- `data/bdtopo_nantes/BDTOPO_3-3_TOUSTHEMES_SHP_LAMB93_R76_2022-12-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D009_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D011_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D031_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D032_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D081_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D082_2022-03-15.7z`
 
 *Only for simulation:*
 
@@ -65,19 +76,8 @@ updated continuously.
 
 ## Generating the population
 
-To generate the synthetic population, the `config.yml` needs to be updated. While
-the relevant code points to the Île-de-France data sets by default, you can
-adjust the paths inidividually. To let the pipeline use the *Zone D* census
-data set and the updated buildings, add the following to `config.yml` in the `config` section:
-
-```yaml
-config:
-  # ...
-  bdtopo_path: bdtopo_toulouse
-  # ...
-```
-
-Furthermore, by default the pipeline will filter all other data sets for the
+To generate the synthetic population, the `config.yml` needs to be updated.
+By default the pipeline will filter all other data sets for the
 Île-de-France region. To make it use the Occitanie region, adjust the
 configuration as follows:
 
@@ -85,7 +85,7 @@ configuration as follows:
 config:
   # ...
   regions: []
-  departments: ["09", 82, 81, 11, 31, 32] # 12 30 34 46 48 65 66
+  departments: ["09", "82", "81", "11", "31", "32"] # 12 30 34 46 48 65 66
   # ...
 ```
 

--- a/docs/population.md
+++ b/docs/population.md
@@ -133,11 +133,17 @@ The geolocated enterprise census is available on data.gouv.fr:
 The French Buildings database is available from IGN:
 
 - [Buildings database](https://geoservices.ign.fr/bdtopo)
-- Click on the right link *BD TOPO® Shapefile Régions* 
-- It will leads you to *BD TOPO® some date Tous Thèmes par région format shapefile projection légale*
-- Download *Région Île-de-France - R 11*
-- Copy the *7z* file into `data/bdtopo_idf`.
-
+- In the sidebar on the right, under *Téléchargement anciennes éditions*, click on *BD TOPO® 2022 GeoPackage Départements* to go to the saved data publications from 2022.
+- The data is split by department and they are identified with a number. For the Île-de-France region, download:
+  - Paris (75)
+  - Seine-et-Marne (77)
+  - Yvelines (78)
+  - Essonne (91)
+  - Hauts-de-Seine (92)
+  - Seine-Saint-Denis (93)
+  - Val-de-Marne (94)
+  - Val-d'Oise (95)
+- Copy the eight *7z* files into `data/bdtopo22`.
 
 ### Overview
 
@@ -161,7 +167,14 @@ Your folder structure should now have at least the following files:
 - `data/sirene/StockEtablissement_utf8.csv`
 - `data/sirene/StockUniteLegale_utf8.zip`
 - `data/sirene/GeolocalisationEtablissement_Sirene_pour_etudes_statistiques_utf8.zip`
-- `data/bdtopo/BDTOPO_3-3_TOUSTHEMES_SHP_LAMB93_R11_2022-12-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D075_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D077_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D078_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D091_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D092_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D093_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D094_2022-03-15.7z`
+- `data/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D095_2022-03-15.7z`
 
 In case you are using the regional household travel survey (EGT), the following
 files should also be in place:

--- a/synthesis/locations/home.py
+++ b/synthesis/locations/home.py
@@ -24,6 +24,7 @@ def execute(context):
 
     # Load all addresses and add IRIS information
     df_addresses = context.stage("data.bdtopo.raw")[["geometry"]]
+    df_addresses["geometry"] = df_addresses["geometry"].centroid
 
     print("Imputing IRIS into addresses ...")
     df_addresses = gpd.sjoin(df_addresses,

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -553,6 +553,7 @@ def create(output_path):
 
     x = df_selection["geometry"].centroid.x.values
     y = df_selection["geometry"].centroid.y.values
+    z = random.randint(100, 400, observations) # Not used but keeping unit test hashes constant
 
     df_bdtopo = gpd.GeoDataFrame({
         "nombre_de_logements": random.randint(0, 10, observations),

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -568,7 +568,7 @@ def create(output_path):
     df_bdtopo.set_geometry(df_bdtopo.buffer(40),inplace=True,drop=True,crs="EPSG:2154")
 
     os.mkdir("{}/bdtopo22".format(output_path))
-    df_bdtopo.to_file("{}/bdtopo22/content.gpkg".format(output_path))
+    df_bdtopo.to_file("{}/bdtopo22/content.gpkg".format(output_path), layer = "batiment")
 
     bdtopo_date = "2022-03-15"
     bdtopo_departments = ["1A", "1B", "1C", "1D", "2A", "2B", "2C", "2D"]

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -571,7 +571,7 @@ def create(output_path):
     df_bdtopo.to_file("{}/bdtopo22/content.gpkg".format(output_path))
 
     bdtopo_date = "2022-03-15"
-    bdtopo_departments = [75, 77, 78, 91, 92, 93, 94, 95]
+    bdtopo_departments = ["1A", "1B", "1C", "1D", "2A", "2B", "2C", "2D"]
 
     with py7zr.SevenZipFile("{}/bdtopo22/bdtopo.7z".format(output_path), "w") as archive:
         archive.write("{}/bdtopo22/content.gpkg".format(output_path), "content/content.gpkg")

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -2,7 +2,7 @@ import geopandas as gpd
 import pandas as pd
 import shapely.geometry as geo
 import numpy as np
-import os
+import os, shutil
 import py7zr, zipfile
 import glob
 import subprocess
@@ -553,26 +553,37 @@ def create(output_path):
 
     x = df_selection["geometry"].centroid.x.values
     y = df_selection["geometry"].centroid.y.values
-    z = random.randint(100, 400, observations) 
 
     df_bdtopo = gpd.GeoDataFrame({
-        "NB_LOGTS": random.randint(0, 10, observations),
-        "ID": random.randint(1000, 1000000, observations),
+        "nombre_de_logements": random.randint(0, 10, observations),
+        "cleabs": random.randint(1000, 1000000, observations),
         "geometry": [
-            geo.Point(x, y,z) for x, y,z in zip(x, y,z)
+            geo.Point(x, y) for x, y in zip(x, y)
         ]
     }, crs = "EPSG:2154")
+
+    df_bdtopo["cleabs"] = df_bdtopo["cleabs"].apply(lambda x: "AAAAAAAA{:016d}".format(x))
 
     # polygons as buildings from iris centroid points
     df_bdtopo.set_geometry(df_bdtopo.buffer(40),inplace=True,drop=True,crs="EPSG:2154")
 
-    os.mkdir("%s/bdtopo_idf" % output_path)
-    df_bdtopo.to_file("%s/bdtopo_idf/BATIMENT.shp" % output_path)
+    os.mkdir("{}/bdtopo22".format(output_path))
+    df_bdtopo.to_file("{}/bdtopo22/content.gpkg".format(output_path))
 
-    with py7zr.SevenZipFile("%s/bdtopo_idf/bdtopo.7z" % output_path, "w") as archive:
-        for source in glob.glob("%s/bdtopo_idf/BATIMENT.*" % output_path):
-            archive.write(source, "content/{}".format(source.split("/")[-1]))
-            os.remove(source)
+    bdtopo_date = "2022-03-15"
+    bdtopo_departments = [75, 77, 78, 91, 92, 93, 94, 95]
+
+    with py7zr.SevenZipFile("{}/bdtopo22/bdtopo.7z".format(output_path), "w") as archive:
+        archive.write("{}/bdtopo22/content.gpkg".format(output_path), "content/content.gpkg")
+        os.remove("{}/bdtopo22/content.gpkg".format(output_path))
+    
+    for department in bdtopo_departments:
+        shutil.copyfile(
+            "{}/bdtopo22/bdtopo.7z".format(output_path), 
+            "{}/bdtopo22/BDTOPO_3-0_TOUSTHEMES_GPKG_LAMB93_D0{}_{}.7z".format(
+                output_path, department, bdtopo_date))
+        
+    os.remove("{}/bdtopo22/bdtopo.7z".format(output_path))
         
     # Data set: SIRENE
     print("Creating SIRENE ...")

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -687,7 +687,6 @@ def create(output_path):
 
 
     import subprocess
-    import shutil
 
     subprocess.check_call([
         shutil.which("osmosis"), "--read-xml", "%s/osm_idf/ile-de-france-220101.osm.gz" % output_path,


### PR DESCRIPTION
Closes #178. To increase reproducibility of the pipeline, we now make use of stable and long-term available BD-TOPO data from 2022 (which will be updated annually). Since this data is only available on the department level, a new logic has been implemented: The pipeline expects the IGN files for the configured departments in the data folder (in `bdtopo22`). The user, hence, only needs to dump the correct files into that folder. As a nice side effect, this simplifies configuration for non-IDF scenarios.