### PR TITLE
chore: optimistically skip testing of maven dependencies

### DIFF
--- a/matsim/runtime/eqasim.py
+++ b/matsim/runtime/eqasim.py
@@ -40,7 +40,7 @@ def execute(context):
         ])
 
         # Build eqasim
-        maven.run(context, ["-Pstandalone", "--projects", "ile_de_france", "--also-make", "package"], cwd = "%s/eqasim-java" % context.path())
+        maven.run(context, ["-Pstandalone", "--projects", "ile_de_france", "--also-make", "package", "-DskipTests=true"], cwd = "%s/eqasim-java" % context.path())
         jar_path = "%s/eqasim-java/ile_de_france/target/ile_de_france-%s.jar" % (context.path(), version)
 
     # Special case: We provide the jar directly. This is mainly used for

--- a/matsim/runtime/pt2matsim.py
+++ b/matsim/runtime/pt2matsim.py
@@ -37,7 +37,7 @@ def execute(context):
     ])
 
     # Build pt2matsim
-    maven.run(context, ["package"], cwd = "%s/pt2matsim" % context.path())
+    maven.run(context, ["package", "-DskipTests=true"], cwd = "%s/pt2matsim" % context.path())
     jar_path = "%s/pt2matsim/target/pt2matsim-%s-shaded.jar" % (context.path(), version)
 
     # Test pt2matsim


### PR DESCRIPTION
Closes #170. We don't need to run all the integration tests in the Maven dependencies inside the pipeline.