### PR TITLE
fix: Resolve segfault in statistical matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Fix: Segfault in statistical matching caused by `numba` in recent versions
 - Increase reproducibility for BD-TOPO by requiring user to dump the IGN files in 7z'ed GPKG format into one central folder for `bdtopo22`
 - Fix: Correctly treat non-movers in CEREMA EDGT for Lyon
 - Fix: Properly treat non-movers in EDGT Lyon ADISP data

--- a/synthesis/population/matched.py
+++ b/synthesis/population/matched.py
@@ -30,7 +30,7 @@ def configure(context):
     hts = context.config("hts")
     context.stage("data.hts.selected", alias = "hts")
 
-# @numba.jit(nopython = True, parallel = True)
+@numba.jit(nopython = True) # Already parallelized parallel = True)
 def sample_indices(uniform, cdf, selected_indices):
     indices = np.arange(len(uniform))
 

--- a/synthesis/population/matched.py
+++ b/synthesis/population/matched.py
@@ -30,7 +30,7 @@ def configure(context):
     hts = context.config("hts")
     context.stage("data.hts.selected", alias = "hts")
 
-@numba.jit(nopython = True, parallel = True)
+# @numba.jit(nopython = True, parallel = True)
 def sample_indices(uniform, cdf, selected_indices):
     indices = np.arange(len(uniform))
 


### PR DESCRIPTION
I just noticed that in smaller machines, the parallelization of numba actually slows down the statistical matching (because it is already parallelized and numba will use multiple threads per process). But now this even lead to segfaults for some reason. So I just disabled the parallel mode for numba and things work fine and much faster on medium-sized machines.