### PR TITLE
fix: read order for files discovered using glob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- Fix read order when exploring files using `glob`
 - Modes are only written now to `trips.csv` if `mode_choice` is activated
 - Update to `eqasim-java` commit `7cbe85b`
 - Adding optional `eqasim-java`-based mode choice step using the `mode_choice` configuration option

--- a/data/ban/raw.py
+++ b/data/ban/raw.py
@@ -52,7 +52,7 @@ def execute(context):
     return df_ban[["geometry"]]
 
 def find_ban(path):
-    candidates = list(glob.glob("{}/*.csv.gz".format(path)))
+    candidates = sorted(list(glob.glob("{}/*.csv.gz".format(path))))
 
     if len(candidates) == 0:
         raise RuntimeError("BAN data is not available in {}".format(path))

--- a/data/bdtopo/raw.py
+++ b/data/bdtopo/raw.py
@@ -105,7 +105,7 @@ def execute(context):
     return df_bdtopo[["building_id", "housing", "geometry"]]
 
 def find_bdtopo(path):
-    candidates = list(glob.glob("{}/*.7z".format(path)))
+    candidates = sorted(list(glob.glob("{}/*.7z".format(path))))
 
     if len(candidates) == 0:
         raise RuntimeError("BD TOPO data is not available in {}".format(path))

--- a/data/gtfs/output.py
+++ b/data/gtfs/output.py
@@ -18,7 +18,7 @@ def execute(context):
     f = zipfile.ZipFile(output_path, 'w', zipfile.ZIP_DEFLATED)
     print(source_path)
 
-    for path in glob.glob("%s/*.txt" % source_path):
+    for path in sorted(list(glob.glob("%s/*.txt" % source_path))):
         name = path.replace(source_path, "")[1:]
 
         if len(name) > 0:

--- a/data/osm/cleaned.py
+++ b/data/osm/cleaned.py
@@ -99,8 +99,8 @@ def execute(context):
     return "output.osm.gz"
 
 def get_input_files(base_path):
-    osm_paths = list(glob.glob("{}/*.osm.pbf".format(base_path)))
-    osm_paths += list(glob.glob("{}/*.osm.xml".format(base_path)))
+    osm_paths = sorted(list(glob.glob("{}/*.osm.pbf".format(base_path))))
+    osm_paths += sorted(list(glob.glob("{}/*.osm.xml".format(base_path))))
 
     if len(osm_paths) == 0:
         raise RuntimeError("Did not find any OSM data (.osm.pbf) in {}".format(base_path))

--- a/data/spatial/iris.py
+++ b/data/spatial/iris.py
@@ -55,7 +55,7 @@ def execute(context):
     return df_iris
 
 def find_iris(path):
-    candidates = list(glob.glob("{}/*.7z".format(path)))
+    candidates = sorted(list(glob.glob("{}/*.7z".format(path))))
 
     if len(candidates) == 0:
         raise RuntimeError("IRIS data is not available in {}".format(path))


### PR DESCRIPTION
At multiple points in the pipeline, we explore the files to read using `glob`. However, the order of `glob` is undefined, especially on different systems. This PR orders the explored files by name wherever `glob` is used. This is a potential fix for #202.