### PR TITLE
fix: conda dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,10 +19,11 @@ dependencies:
   - openpyxl=3.1.0
   - pip=23.0.1
   - python=3.10.10
-  - py7zr=0.20.4
+  - py7zr=0.20.8
   - pytest=7.2.2
   - xlwt=1.3.0
   - fiona=1.9.2
+  - sqlite=3.42.0
 
   - pip:
     - synpp==1.5.1


### PR DESCRIPTION
Update for dependencies:
- `py7zr=0.20.4` is not available anymore
- `sqlite=3.42.0` was an implicit dependency before, but conda selects a newer version that makes unit tests fail now