### PR TITLE
Feat: Generating PT legs during mode choice + skipping routing during mode choice + update to Eqasim 1.5.0 (v2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v4
       with:
         distribution: "corretto"
         java-version: "17"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        distribution: "adopt"
+        distribution: "corretto"
         java-version: "17"
     - uses: actions/cache@v2
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         distribution: "adopt"
-        java-version: "11"
+        java-version: "17"
     - uses: actions/cache@v2
       env:
         CACHE_NUMBER: 0

--- a/docs/cases/corsica.md
+++ b/docs/cases/corsica.md
@@ -45,7 +45,7 @@ Download all the *zip*'d GTFS schedules and put them into the folder `data/gtfs_
 You need to download the region-specific adresses database :
 
 - [Adresses database](https://adresse.data.gouv.fr/data/ban/adresses/latest/csv/)
-- Click on the link *adresses-xx.csv.gz* where xx = departments codes (09, 11, 31, 32, 81, 82) 
+- Click on the link *adresses-xx.csv.gz* where xx = departments codes (2A and 2B) 
 - Copy the *gz* files into `data/ban_corsica`.
 
 

--- a/matsim/runtime/eqasim.py
+++ b/matsim/runtime/eqasim.py
@@ -6,7 +6,7 @@ import matsim.runtime.java as java
 import matsim.runtime.maven as maven
 
 DEFAULT_EQASIM_VERSION = "1.3.1"
-DEFAULT_EQASIM_COMMIT = "7cbe85b"
+DEFAULT_EQASIM_COMMIT = "e5545a8"
 
 def configure(context):
     context.stage("matsim.runtime.git")

--- a/matsim/runtime/eqasim.py
+++ b/matsim/runtime/eqasim.py
@@ -5,9 +5,9 @@ import matsim.runtime.git as git
 import matsim.runtime.java as java
 import matsim.runtime.maven as maven
 
-DEFAULT_EQASIM_VERSION = "1.3.1"
+DEFAULT_EQASIM_VERSION = "1.5.0"
 DEFAULT_EQASIM_BRANCH = "develop"
-DEFAULT_EQASIM_COMMIT = "7cbe85b"
+DEFAULT_EQASIM_COMMIT = "cc81ec8"
 
 def configure(context):
     context.stage("matsim.runtime.git")

--- a/matsim/runtime/eqasim.py
+++ b/matsim/runtime/eqasim.py
@@ -7,7 +7,7 @@ import matsim.runtime.maven as maven
 
 DEFAULT_EQASIM_VERSION = "1.5.0"
 DEFAULT_EQASIM_BRANCH = "develop"
-DEFAULT_EQASIM_COMMIT = "cc81ec8"
+DEFAULT_EQASIM_COMMIT = "f1af717"
 
 def configure(context):
     context.stage("matsim.runtime.git")

--- a/matsim/simulation/prepare.py
+++ b/matsim/simulation/prepare.py
@@ -144,15 +144,22 @@ def execute(context):
     
     # Optionally, perform mode choice
     if context.config("mode_choice"):
-        eqasim.run(context, "org.eqasim.ile_de_france.RunModeChoice", [
+        eqasim.run(context, "org.eqasim.ile_de_france.standalone_mode_choice.RunStandaloneModeChoice", [
             "--config-path", "%sconfig.xml" % context.config("output_prefix"),
-            "--output-plans-path", "%spopulation.xml.gz" % context.config("output_prefix"),
+            "--config:standaloneModeChoice.outputDirectory", "mode_choice",
+            "--config:standaloneModeChoice.removePersonsWithNoValidAlternatives", "true",
             "--config:global.numberOfThreads", context.config("processes"),
-            "--output-csv-path", "%stripModes.csv" % context.config("output_prefix")
+            "--write-output-csv-trips", "true"
         ])
 
-        assert os.path.exists("%s/%stripModes.csv" % (context.path(), context.config("output_prefix")))
-        assert os.path.exists("%s/%spopulation.xml.gz" % (context.path(), context.config("output_prefix")))
+        assert os.path.exists("%s/mode_choice/output_plans.xml.gz" % context.path())
+        assert os.path.exists("%s/mode_choice/output_trips.csv" % context.path())
+        assert os.path.exists("%s/mode_choice/output_pt_legs.csv" % context.path())
+
+        shutil.move("%s/%spopulation.xml.gz" % (context.path(), context.config("output_prefix")),
+                    "%s/%spopulation_pre_mode_choice.xml.gz" % (context.path(), context.config("output_prefix")))
+        shutil.copy("%s/mode_choice/output_plans.xml.gz" % context.path(),
+                    "%s/%spopulation.xml.gz" % (context.path(), context.config("output_prefix")))
 
     # Validate scenario
     eqasim.run(context, "org.eqasim.core.scenario.validation.RunScenarioValidator", [

--- a/matsim/simulation/prepare.py
+++ b/matsim/simulation/prepare.py
@@ -133,14 +133,6 @@ def execute(context):
             "--factor", str(0.8)
         ])
 
-    # Route population
-    eqasim.run(context, "org.eqasim.core.scenario.routing.RunPopulationRouting", [
-        "--config-path", "%sconfig.xml" % context.config("output_prefix"),
-        "--output-path", "%spopulation.xml.gz" % context.config("output_prefix"),
-        "--threads", context.config("processes"),
-        "--config:plans.inputPlansFile", "prepared_population.xml.gz"
-    ])
-    assert os.path.exists("%s/%spopulation.xml.gz" % (context.path(), context.config("output_prefix")))
     
     # Optionally, perform mode choice
     if context.config("mode_choice"):
@@ -149,17 +141,27 @@ def execute(context):
             "--config:standaloneModeChoice.outputDirectory", "mode_choice",
             "--config:standaloneModeChoice.removePersonsWithNoValidAlternatives", "true",
             "--config:global.numberOfThreads", context.config("processes"),
-            "--write-output-csv-trips", "true"
+            "--write-output-csv-trips", "true",
+            "--skip-scenario-check", "true",
+            "--config:plans.inputPlansFile", "prepared_population.xml.gz"
         ])
 
         assert os.path.exists("%s/mode_choice/output_plans.xml.gz" % context.path())
         assert os.path.exists("%s/mode_choice/output_trips.csv" % context.path())
         assert os.path.exists("%s/mode_choice/output_pt_legs.csv" % context.path())
 
-        shutil.move("%s/%spopulation.xml.gz" % (context.path(), context.config("output_prefix")),
-                    "%s/%spopulation_pre_mode_choice.xml.gz" % (context.path(), context.config("output_prefix")))
         shutil.copy("%s/mode_choice/output_plans.xml.gz" % context.path(),
                     "%s/%spopulation.xml.gz" % (context.path(), context.config("output_prefix")))
+    else:
+        # Route population
+        eqasim.run(context, "org.eqasim.core.scenario.routing.RunPopulationRouting", [
+            "--config-path", "%sconfig.xml" % context.config("output_prefix"),
+            "--output-path", "%spopulation.xml.gz" % context.config("output_prefix"),
+            "--threads", context.config("processes"),
+            "--config:plans.inputPlansFile", "prepared_population.xml.gz"
+        ])
+
+    assert os.path.exists("%s/%spopulation.xml.gz" % (context.path(), context.config("output_prefix")))
 
     # Validate scenario
     eqasim.run(context, "org.eqasim.core.scenario.validation.RunScenarioValidator", [

--- a/matsim/simulation/prepare.py
+++ b/matsim/simulation/prepare.py
@@ -139,7 +139,6 @@ def execute(context):
         eqasim.run(context, "org.eqasim.ile_de_france.standalone_mode_choice.RunStandaloneModeChoice", [
             "--config-path", "%sconfig.xml" % context.config("output_prefix"),
             "--config:standaloneModeChoice.outputDirectory", "mode_choice",
-            "--config:standaloneModeChoice.removePersonsWithNoValidAlternatives", "true",
             "--config:global.numberOfThreads", context.config("processes"),
             "--write-output-csv-trips", "true",
             "--skip-scenario-check", "true",

--- a/matsim/writers.py
+++ b/matsim/writers.py
@@ -94,15 +94,18 @@ class PopulationWriter(XmlWriter):
         self._write_line('</person>')
 
     def start_attributes(self):
-        self._require_scope(self.PERSON_SCOPE)
+        # We don't require any scope here because attributes can be almost anywhere
         self._write_line('<attributes>')
         self.indent += 1
+        # And we need to remember which scope we were in before starting the attributes
+        self._pre_attributes_scope = self.scope
         self.scope = self.ATTRIBUTES_SCOPE
 
     def end_attributes(self):
         self._require_scope(self.ATTRIBUTES_SCOPE)
         self.indent -= 1
-        self.scope = self.PERSON_SCOPE
+        # Resetting the scope that we were in before starting the attributes
+        self.scope = self._pre_attributes_scope
         self._write_line('</attributes>')
 
     def add_attribute(self, name, type, value):
@@ -143,7 +146,11 @@ class PopulationWriter(XmlWriter):
         self._write('mode="%s" ' % mode)
         self._write('dep_time="%s" ' % self.time(departure_time))
         self._write('trav_time="%s" ' % self.time(travel_time))
-        self._write('/>\n')
+        self._write('>\n')
+        self.start_attributes()
+        self.add_attribute('routingMode', 'java.lang.String', mode)
+        self.end_attributes()
+        self._write_line('</leg>')
 
 class HouseholdsWriter(XmlWriter):
     HOUSEHOLDS_SCOPE = 0

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -133,7 +133,7 @@ def _test_determinism_matsim(index, data_path, tmpdir):
         #"ile_de_france_network.xml.gz":     "5f10ec295b49d2bb768451c812955794",
         "ile_de_france_households.xml.gz":  "64a0c9fab72aad51bc6adb926a1c9d44",
         #"ile_de_france_facilities.xml.gz":  "5ad41afff9ae5c470082510b943e6778",
-        "ile_de_france_config.xml":         "f374807f12a5151fe1efb6e9904e1a56"
+        "ile_de_france_config.xml":         "481fac5fb3e7b90810caa38ff460c00a"
     }
 
     # activities.gpkg, trips.gpkg, meta.json,


### PR DESCRIPTION
The first PR was having problems testing so I re-created it here
This PR proposes the following enhancements:

- Generating a pt legs csv file during mode choice, allowing to directly analyze PT usage by the generated population
- When using the mode choice, the population routing is skipped since routing already happens during the mode choice. This required to write the trip mode in the routingMode attribute when converting the trips csv file to a MATSim plans file in the matsim.scenario.population stage. For that the matsim/writers.py script was changed a bit.
- Along the way the pipeline was updated to use Eqasim 1.5.0