### PR TITLE
feat: optionally not run MATSim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- feat: make it possible to disable the test run of MATSim before writing everything out
 - feat: check availability of open data sources for every PR
 - feat: make statistical matching attribute list configurable
 - feat: add urban type classifiation (unité urbaine)

--- a/matsim/output.py
+++ b/matsim/output.py
@@ -1,7 +1,10 @@
 import shutil
 
 def configure(context):
-    context.stage("matsim.simulation.run")
+    if context.config("run_matsim", True):
+        # allow disabling performing one run of the simulation
+        context.stage("matsim.simulation.run")
+    
     context.stage("matsim.simulation.prepare")
     context.stage("matsim.runtime.eqasim")
 


### PR DESCRIPTION
We have some servers that manage to create the simulation data for a 10% sample, but then they don't manage to fit the mode choice in the two test iterations into memory. This PR adds a config option that allows disabling the previously obligatory run of two MATSim iterations before writing out the MATSim files.