### PR TITLE
feat(output): export all outputs in parquet files

### DIFF
--- a/docs/population.md
+++ b/docs/population.md
@@ -238,6 +238,8 @@ and arranging all the raw data sets as described above.
 - `output_path`: This should be the path to the folder where the output data
 of the pipeline should be stored. It must exist and should ideally be empty
 for now.
+- `output_formats`: This should specify the formats of outputs. Available formats are
+csv, gpkg, parquet and geoparquet. Default value is csv and gpkg: ["csv", "gpkg"].
 
 To set up the working/output directory, create, for instance, a `cache` and a
 `output` directory. These are already configured in `config.yml`:

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - fiona=1.9.2
   - sqlite=3.42.0
   - mock=5.1.0
-  - pyarrow=16.1.0
+  - pyarrow=14.0.2
 
   - pip:
     - synpp==1.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,7 @@ dependencies:
   - xlwt=1.3.0
   - fiona=1.9.2
   - sqlite=3.42.0
+  - pyarrow=16.1.0
 
   - pip:
     - synpp==1.5.1

--- a/synthesis/output.py
+++ b/synthesis/output.py
@@ -75,6 +75,7 @@ def execute(context):
     ]]
 
     df_households.to_csv("%s/%shouseholds.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    df_households.to_parquet("%s/%shouseholds.parquet" % (output_path, output_prefix))
 
     # Prepare persons
     df_persons = context.stage("synthesis.population.enriched").rename(
@@ -89,6 +90,7 @@ def execute(context):
     ]]
 
     df_persons.to_csv("%s/%spersons.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    df_persons.to_parquet("%s/%spersons.parquet" % (output_path, output_prefix))
 
     # Prepare activities
     df_activities = context.stage("synthesis.population.activities").rename(
@@ -171,15 +173,20 @@ def execute(context):
     path = "%s/%sactivities.gpkg" % (output_path, output_prefix)
     df_spatial.to_file(path, driver = "GPKG")
     clean_gpkg(path)
+    path = "%s/%sactivities.geoparquet" % (output_path, output_prefix)
+    df_spatial.to_parquet(path)
 
     # Write spatial homes
     path = "%s/%shomes.gpkg" % (output_path, output_prefix)
-    df_spatial[
+    df_spatial_homes = df_spatial[
         df_spatial["purpose"] == "home"
     ].drop_duplicates("household_id")[[
         "household_id", "geometry"
-    ]].to_file(path, driver = "GPKG")
+    ]]
+    df_spatial_homes.to_file(path, driver = "GPKG")
     clean_gpkg(path)
+    path = "%s/%shomes.geoparquet" % (output_path, output_prefix)
+    df_spatial_homes.to_parquet(path)
 
     # Write spatial commutes
     df_spatial = pd.merge(
@@ -196,6 +203,8 @@ def execute(context):
     path = "%s/%scommutes.gpkg" % (output_path, output_prefix)
     df_spatial.to_file(path, driver = "GPKG")
     clean_gpkg(path)
+    path = "%s/%scommutes.geoparquet" % (output_path, output_prefix)
+    df_spatial.to_parquet(path)
 
     # Write spatial trips
     df_spatial = pd.merge(df_trips, df_locations[[
@@ -229,3 +238,5 @@ def execute(context):
     path = "%s/%strips.gpkg" % (output_path, output_prefix)
     df_spatial.to_file(path, driver = "GPKG")
     clean_gpkg(path)
+    path = "%s/%strips.geoparquet" % (output_path, output_prefix)
+    df_spatial.to_parquet(path)

--- a/synthesis/output.py
+++ b/synthesis/output.py
@@ -22,6 +22,7 @@ def configure(context):
 
     context.config("output_path")
     context.config("output_prefix", "ile_de_france_")
+    context.config("output_formats", ["csv", "gpkg"])
     
     if context.config("mode_choice", False):
         context.stage("matsim.simulation.prepare")
@@ -60,6 +61,7 @@ def clean_gpkg(path):
 def execute(context):
     output_path = context.config("output_path")
     output_prefix = context.config("output_prefix")
+    output_formats = context.config("output_formats")
 
     # Prepare households
     df_households = context.stage("synthesis.population.enriched").rename(
@@ -73,9 +75,10 @@ def execute(context):
         "income",
         "census_household_id"
     ]]
-
-    df_households.to_csv("%s/%shouseholds.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
-    df_households.to_parquet("%s/%shouseholds.parquet" % (output_path, output_prefix))
+    if "csv" in output_formats:
+        df_households.to_csv("%s/%shouseholds.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    if "parquet" in output_formats:
+        df_households.to_parquet("%s/%shouseholds.parquet" % (output_path, output_prefix))
 
     # Prepare persons
     df_persons = context.stage("synthesis.population.enriched").rename(
@@ -88,9 +91,10 @@ def execute(context):
         "has_driving_license", "has_pt_subscription",
         "census_person_id", "hts_id"
     ]]
-
-    df_persons.to_csv("%s/%spersons.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
-    df_persons.to_parquet("%s/%spersons.parquet" % (output_path, output_prefix))
+    if "csv" in output_formats:
+        df_persons.to_csv("%s/%spersons.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    if "parquet" in output_formats:
+        df_persons.to_parquet("%s/%spersons.parquet" % (output_path, output_prefix))
 
     # Prepare activities
     df_activities = context.stage("synthesis.population.activities").rename(
@@ -111,7 +115,10 @@ def execute(context):
         "is_first", "is_last"
     ]]
 
-    df_activities.to_csv("%s/%sactivities.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    if "csv" in output_formats:
+        df_activities.to_csv("%s/%sactivities.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    if "parquet" in output_formats:
+        df_activities.to_parquet("%s/%sactivities.parquet" % (output_path, output_prefix))
 
     # Prepare trips
     df_trips = context.stage("synthesis.population.trips").rename(
@@ -149,7 +156,10 @@ def execute(context):
 
         assert not np.any(df_trips["mode"].isna())                                 
 
-    df_trips.to_csv("%s/%strips.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    if "csv" in output_formats:
+        df_trips.to_csv("%s/%strips.csv" % (output_path, output_prefix), sep = ";", index = None, lineterminator = "\n")
+    if "parquet" in output_formats:
+        df_trips.to_csv("%s/%strips.parquet" % (output_path, output_prefix))
 
     if context.config("generate_vehicles_file"):
         # Prepare vehicles
@@ -170,23 +180,27 @@ def execute(context):
     # Write spatial activities
     df_spatial = gpd.GeoDataFrame(df_activities, crs = "EPSG:2154")
     df_spatial["purpose"] = df_spatial["purpose"].astype(str)
-    path = "%s/%sactivities.gpkg" % (output_path, output_prefix)
-    df_spatial.to_file(path, driver = "GPKG")
-    clean_gpkg(path)
-    path = "%s/%sactivities.geoparquet" % (output_path, output_prefix)
-    df_spatial.to_parquet(path)
+    if "gpkg" in output_formats:
+        path = "%s/%sactivities.gpkg" % (output_path, output_prefix)
+        df_spatial.to_file(path, driver = "GPKG")
+        clean_gpkg(path)
+    if "geoparquet" in output_formats:
+        path = "%s/%sactivities.geoparquet" % (output_path, output_prefix)
+        df_spatial.to_parquet(path)
 
     # Write spatial homes
-    path = "%s/%shomes.gpkg" % (output_path, output_prefix)
     df_spatial_homes = df_spatial[
         df_spatial["purpose"] == "home"
     ].drop_duplicates("household_id")[[
         "household_id", "geometry"
     ]]
-    df_spatial_homes.to_file(path, driver = "GPKG")
-    clean_gpkg(path)
-    path = "%s/%shomes.geoparquet" % (output_path, output_prefix)
-    df_spatial_homes.to_parquet(path)
+    if "gpkg" in output_formats:
+        path = "%s/%shomes.gpkg" % (output_path, output_prefix)
+        df_spatial_homes.to_file(path, driver = "GPKG")
+        clean_gpkg(path)
+    if "geoparquet" in output_formats:
+        path = "%s/%shomes.geoparquet" % (output_path, output_prefix)
+        df_spatial_homes.to_parquet(path)
 
     # Write spatial commutes
     df_spatial = pd.merge(
@@ -200,11 +214,13 @@ def execute(context):
     ]
 
     df_spatial = df_spatial.drop(columns = ["home_geometry", "work_geometry"])
-    path = "%s/%scommutes.gpkg" % (output_path, output_prefix)
-    df_spatial.to_file(path, driver = "GPKG")
-    clean_gpkg(path)
-    path = "%s/%scommutes.geoparquet" % (output_path, output_prefix)
-    df_spatial.to_parquet(path)
+    if "gpkg" in output_formats:
+        path = "%s/%scommutes.gpkg" % (output_path, output_prefix)
+        df_spatial.to_file(path, driver = "GPKG")
+        clean_gpkg(path)
+    if "geoparquet" in output_formats:
+        path = "%s/%scommutes.geoparquet" % (output_path, output_prefix)
+        df_spatial.to_parquet(path)
 
     # Write spatial trips
     df_spatial = pd.merge(df_trips, df_locations[[
@@ -234,9 +250,11 @@ def execute(context):
 
     if "mode" in df_spatial:
         df_spatial["mode"] = df_spatial["mode"].astype(str)
-    
-    path = "%s/%strips.gpkg" % (output_path, output_prefix)
-    df_spatial.to_file(path, driver = "GPKG")
-    clean_gpkg(path)
-    path = "%s/%strips.geoparquet" % (output_path, output_prefix)
-    df_spatial.to_parquet(path)
+
+    if "gpkg" in output_formats:
+        path = "%s/%strips.gpkg" % (output_path, output_prefix)
+        df_spatial.to_file(path, driver = "GPKG")
+        clean_gpkg(path)
+    if "geoparquet" in output_formats:
+        path = "%s/%strips.geoparquet" % (output_path, output_prefix)
+        df_spatial.to_parquet(path)


### PR DESCRIPTION
Add export for all outputs in parquet files. All existing exports are kept. New parquet files are added.
Parquet files use .parquet extension. And geospatial files use .geoparquet extension.
Pyarrow package dependency is added.

Parquet format is extremely faster to read than GeoPackage files and csv. For example on trips data on 10% population for departement 14, it takes 25 seconds to read in GeoPackage, and only 0.17 seconds in Parquet.