### PR TITLE
fix: update pyarrow to latest version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,9 +12,9 @@ dependencies:
   - numba=0.56.4
   - palettable=3.3.0
   - scikit-learn=1.2.2
-  - shapely=2.0.1
+  - shapely=2.0.2
   - tqdm=4.65.0
-  - pytables=3.7.0
+  - pytables=3.9.2
   - xlrd=2.0.1
   - openpyxl=3.1.0
   - pip=23.0.1
@@ -23,9 +23,9 @@ dependencies:
   - pytest=7.2.2
   - xlwt=1.3.0
   - fiona=1.9.2
-  - sqlite=3.42.0
+  - sqlite=3.46.0
   - mock=5.1.0
-  - pyarrow=14.0.2
+  - pyarrow=16.1.0
 
   - pip:
     - synpp==1.5.1

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -75,10 +75,10 @@ def _test_determinism(index, data_path, tmpdir):
     }
 
     REFERENCE_GPKG_HASHES = {
-        "ile_de_france_activities.gpkg":    "4ef01c82b09e81e54cc6b7d59145123e",
-        "ile_de_france_commutes.gpkg":      "a03554ee745e9a47a6b1ea4126a13c2a",
-        "ile_de_france_homes.gpkg":         "3533f4756e3ee126618bb17f059033bd",
-        "ile_de_france_trips.gpkg":         "982b83f27e231766d04b3f9351d84daa",
+        "ile_de_france_activities.gpkg":    "af01e94e7806365ba6df68d5bbdaf2f0",
+        "ile_de_france_commutes.gpkg":      "5f8e25abe9b69b3edc337fa85c794629",
+        "ile_de_france_homes.gpkg":         "033d1aa7a5350579cbd5e8213b9736f2",
+        "ile_de_france_trips.gpkg":         "4c69b78e7d1b9091d6e19a03a33a0314",
     }
 
     generated_csv_hashes = {


### PR DESCRIPTION
For some reason, the environment runs well on Linux and Windows in CI, but it cannot be resolved on our Linux servers. Trying to update `pyarrow` here to check if it solves the problem (the indicated configuration works on our servers now). I have the feeling that the update of `sqlite` changed some unit tests before. Let's see what the automated tests say.