### PR TITLE
fix: random seeds in secondary location model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- fix: secondary location model used same random seed in every parallel thread
 - feat: make it possible to disable the test run of MATSim before writing everything out
 - feat: check availability of open data sources for every PR
 - feat: make statistical matching attribute list configurable

--- a/synthesis/population/spatial/secondary/locations.py
+++ b/synthesis/population/spatial/secondary/locations.py
@@ -130,7 +130,7 @@ def process(context, arguments):
   df_trips, df_primary, random_seed = arguments
 
   # Set up RNG
-  random = np.random.RandomState(context.config("random_seed"))
+  random = np.random.RandomState(random_seed)
   maximum_iterations = context.config("secloc_maximum_iterations")
 
   # Set up discretization solver

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -75,10 +75,10 @@ def _test_determinism(index, data_path, tmpdir):
     }
 
     REFERENCE_GPKG_HASHES = {
-        "ile_de_france_activities.gpkg":    "f8a4138f0dc92802d36ae30e449bfc74",
+        "ile_de_france_activities.gpkg":    "9cf9a5fd8927c709927f7a940f86efbf",
         "ile_de_france_commutes.gpkg":      "5a4180390a69349cc655c07c5671e8d3",
         "ile_de_france_homes.gpkg":         "033d1aa7a5350579cbd5e8213b9736f2",
-        "ile_de_france_trips.gpkg":         "5248a832eb56797b6f298c5aeb653dac",
+        "ile_de_france_trips.gpkg":         "d0aec4033cfc184bf1b91ae13a537ef8",
     }
 
     generated_csv_hashes = {


### PR DESCRIPTION
The secondary location model got individual random seeds passed to every parallel process. However, so far, it was using the global random seed instead. This should not have a big impact as every thread processes different activity chains, but there may still be some minor effects in terms of correlations between similar activity chains that are now resolved.