### PR TITLE
fix: repair completely overlapping trips in ENTD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- fix: fixed special case in repairing ENTD for completely overlapping trips
 - feat: make it possible to disable the test run of MATSim before writing everything out
 - feat: check availability of open data sources for every PR
 - feat: make statistical matching attribute list configurable

--- a/data/hts/hts.py
+++ b/data/hts/hts.py
@@ -89,12 +89,13 @@ def fix_trip_times(df_trips):
     print("  of which we're able to shorten %d to make it consistent" % np.count_nonzero(f))
     df_main.loc[f, "arrival_time"] = df_next["departure_time"]
 
-    # Included trips
+    # Included trips (moving the first one to the start of the following trip and setting duration to zero)
     f = ~df_main["is_last_trip"]
     f &= df_main["departure_time"] >= df_next["departure_time"]
     f &= df_main["arrival_time"] <= df_next["arrival_time"]
+    df_main.loc[f, "departure_time"] = df_next["departure_time"]
+    df_main.loc[f, "arrival_time"] = df_next["departure_time"]
     print("Found %d occurences where current trip is included in next trip" % np.count_nonzero(f))
-    df_main = df_main[~f]
 
     return df_main
 


### PR DESCRIPTION
The cleaning logic for ENTD covered trips that are entirely contained in another trip along the chain of a person. Those trips (actually, there is only one in the whole data set) were deleted so far. However, this causes a problem when checking for the consistency of activity types along the chain later on. So far, we didn't notice this, because we never used the entire ENTD, but only filtered data sets for individual sets of departments. The problem is now fixed by squeezing the first trip to duration zero and setting departure time and arrival time to the departure time of the following trip.

![image](https://github.com/eqasim-org/ile-de-france/assets/647500/eddb33a1-8320-4a2a-b442-e47a83ab7388)
