### PR TITLE
fix: avoid regenerating network and transit when population changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Under development**
 
+- fix: avoid regenerating OSM when population changes
 - feat: add municipality information to households and activities
 - chore: update to `eqasim-java` commit `ece4932`
 - feat: vehicles and vehicle types are now always generated

--- a/matsim/scenario/supply/osm.py
+++ b/matsim/scenario/supply/osm.py
@@ -6,13 +6,13 @@ def configure(context):
     context.stage("matsim.runtime.java")
     context.stage("matsim.runtime.pt2matsim")
     context.stage("data.osm.cleaned")
-    context.stage("synthesis.population.spatial.home.locations")
+    context.stage("data.spatial.iris")
 
     context.config("export_detailed_network", False)
 
 def execute(context):
     osm_path = "%s/output.osm.gz" % context.path("data.osm.cleaned")
-    crs = context.stage("synthesis.population.spatial.home.locations").crs
+    crs = context.stage("data.spatial.iris").crs
 
     pt2matsim.run(context, "org.matsim.pt2matsim.run.CreateDefaultOsmConfig", 
         arguments=["config_template.xml"]


### PR DESCRIPTION
In recent versions of the pipeline the whole conversion of the OSM data plus transit matching was run again once the population home locations have changed. The reason was that we obtained the CRS from there. Now we obtain the right CRS from `data.spatial.iris` which does not change frequently.