### PR TITLE
fix: properly filtering osm data

### DIFF
--- a/data/osm/cleaned.py
+++ b/data/osm/cleaned.py
@@ -23,7 +23,7 @@ def execute(context):
     
     # Prepare bounding area
     df_area = context.stage("data.spatial.municipalities")
-    area = df_area.to_crs("EPSG:4326")["geometry"].values[0]
+    area = df_area.to_crs("EPSG:4326").union_all()
 
     # Read identifiers that are relevant
     tracker = osmium.IdTracker()


### PR DESCRIPTION
I'm cherry picking this change from this bigger PR https://github.com/eqasim-org/ile-de-france/pull/337. As I believe the MATSim part of the pipeline is unusable in without it as only the first municipality is red from the osm files :)

