### PR TITLE
fix(vehicles): use valid hbefa keys for vehicle types

### DIFF
--- a/data/vehicles/types.py
+++ b/data/vehicles/types.py
@@ -15,7 +15,7 @@ def execute(context):
     vehicle_types = [
         {
             'type_id': 'default_car', 'nb_seats': 4, 'length': 5.0, 'width': 1.0, 'pce': 1.0, 'mode': "car",
-            'hbefa_cat': "PASSENGER_CAR", 'hbefa_tech': "average", 'hbefa_size': "average", 'hbefa_emission': "average",
+            'hbefa_cat': "pass. car", 'hbefa_tech': "average", 'hbefa_size': "average", 'hbefa_emission': "average",
         }
     ]
 
@@ -25,19 +25,17 @@ def execute(context):
 
             id = "car_%s_%s" % (technology, euro)
 
-            if technology == "diesel" and euro in ['2', '3']:
-                euro += " (DPF)"
-
-            size = ">=2L" if technology == "petrol" else "<1,4L"
+            size = "not specified"
 
             if technology == "petrol":
                 tech += " (4S)"
 
-            emission = "PC %s Euro-%s" % (tech, euro)
+            concept_tech = technology[0].upper() # first letter upped : "P" for petrol, "D" for diesel
+            em_concept = "PC %s Euro-%s" % (concept_tech, euro)
 
             vehicle_types.append({
                 'type_id': id, 'length': 7.5, 'width': 1.0,
-                'hbefa_cat': "PASSENGER_CAR", 'hbefa_tech': tech, 'hbefa_size': size, 'hbefa_emission': emission,
+                'hbefa_cat': "pass. car", 'hbefa_tech': tech, 'hbefa_size': size, 'hbefa_emission': em_concept,
             })
 
     df_types = pd.DataFrame.from_records(vehicle_types)

--- a/synthesis/vehicles/cars/default.py
+++ b/synthesis/vehicles/cars/default.py
@@ -13,7 +13,7 @@ def execute(context):
 
     df_vehicle_types = pd.DataFrame.from_records([{
         "type_id": "default_car", "nb_seats": 4, "length": 5.0, "width": 1.0, "pce": 1.0, "mode": "car",
-        "hbefa_cat": "PASSENGER_CAR", "hbefa_tech": "average", "hbefa_size": "average", "hbefa_emission": "average",
+        "hbefa_cat": "pass. car", "hbefa_tech": "average", "hbefa_size": "average", "hbefa_emission": "average",
     }])
 
     df_vehicles = df_persons[["person_id"]].copy()

--- a/synthesis/vehicles/passengers/default.py
+++ b/synthesis/vehicles/passengers/default.py
@@ -13,7 +13,7 @@ def execute(context):
 
     df_vehicle_types = pd.DataFrame.from_records([{
         "type_id": "default_car_passenger", "nb_seats": 4, "length": 5.0, "width": 1.0, "pce": 1.0, "mode": "car_passenger",
-        "hbefa_cat": "PASSENGER_CAR", "hbefa_tech": "average", "hbefa_size": "average", "hbefa_emission": "average",
+        "hbefa_cat": "pass. car", "hbefa_tech": "average", "hbefa_size": "average", "hbefa_emission": "average",
     }])
 
     df_vehicles = df_persons[["person_id"]].copy()

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -82,7 +82,7 @@ def _test_determinism(index, data_path, tmpdir):
         "ile_de_france_households.csv":     "e1e805d7f2f5af1c058df7432318e596",
         "ile_de_france_persons.csv":        "14331fd23121c64ba1494a7c1d356702",
         "ile_de_france_trips.csv":          "153a48d6df448af9b32acfe99221fe90",
-        "ile_de_france_vehicle_types.csv":  "00bee1ea6d7bc9af43ae6c7101dd75da",
+        "ile_de_france_vehicle_types.csv":  "af7578c363ed4e7a23163b4ab554a0e1",
         "ile_de_france_vehicles.csv":       "1151d40b07c612b62ec40ff40d3e9272",
     }
 
@@ -148,7 +148,7 @@ def _test_determinism_matsim(index, data_path, tmpdir):
         "ile_de_france_households.xml.gz":  "42fee71fe5ad5906d76c6cf87a354a3f",
         #"ile_de_france_facilities.xml.gz":  "5ad41afff9ae5c470082510b943e6778",
         "ile_de_france_config.xml":         "30871dfbbd2b5bf6922be1dfe20ffe73",
-        "ile_de_france_vehicles.xml.gz":    "69185d7e846ed935046ce74635b7ea96"
+        "ile_de_france_vehicles.xml.gz":    "1f3c393ea69b557798ab0915581e33a4"
     }
 
     # activities.gpkg, trips.gpkg, meta.json,


### PR DESCRIPTION
related to this PR on the java side : https://github.com/eqasim-org/eqasim-java/pull/413

So the problem was that hbefa informations stored in the vehicleType was partially wrong. The `HbefaEmissionsConcept` was not in the right format, and the `HbefaSizeClass` was taken from HBEFA 3 database (now we are working with version 4). And since the chosen Hbefa lookup strategy has a fallback on average vehicle type (with little warning when it happens) it never broke anything. But the categories were never taken into account, and the results were all false (equivalent to a default vehicle fleet).