### PR TITLE
chore(deps): synpp-1.6.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,6 @@ dependencies:
   - pyarrow=19.0.1
 
   - pip:
-    - synpp==1.5.1
+    - synpp==1.6.0
     - bhepop2==2.0.1
     - osmium==4.0.2

--- a/matsim/runtime/java.py
+++ b/matsim/runtime/java.py
@@ -3,7 +3,7 @@ import os, shutil
 
 def configure(context):
     context.config("java_binary", "java")
-    context.config("java_memory", "50G")
+    context.config("java_memory", "50G", volatile = True)
 
 def run(context, entry_point, arguments = [], class_path = None, vm_arguments = [], cwd = None, memory = None, mode = "raise"):
     """


### PR DESCRIPTION
Update to `synpp` version `1.6.0` with the following major improvements:
- The new version allows passing config options via the command line, e.g., `--java_memory 20G` (see https://github.com/eqasim-org/synpp/pull/87)
- The new version allows defining stage options as `volatile` which makes it possible that a Java-based is not reevaluated if it has already run but you change the allowed memory via config (see https://github.com/eqasim-org/synpp/pull/86)