### PR TITLE
feat: add support for HTS import with MobiSurvStd

### DIFF
--- a/data/hts/mobisurvstd/cleaned.py
+++ b/data/hts/mobisurvstd/cleaned.py
@@ -1,0 +1,111 @@
+import polars as pl
+
+"""
+This stage convert the MobiSurvStd survey to the format expected by eqasim.
+"""
+
+
+def configure(context):
+    context.stage("data.hts.mobisurvstd.raw")
+
+    if context.config("use_urban_type", False):
+        context.stage("data.spatial.urban_type")
+
+
+def execute(context):
+    std_survey = context.stage("data.hts.mobisurvstd.raw")
+
+    df_households = std_survey.households.select(
+        "household_id",
+        household_weight="sample_weight",
+        household_size="nb_persons",
+        number_of_vehicles=pl.col("nb_cars") + pl.col("nb_motorcycles"),
+        number_of_bikes="nb_bicycles",
+        departement_id="home_dep",
+    )
+
+    df_persons = std_survey.persons.select(
+        "person_id",
+        "household_id",
+        "age",
+        sex=pl.when("woman").then(pl.lit("female")).otherwise(pl.lit("male")).cast(pl.Categorical),
+        employed=pl.col("professional_occupation") == "worker",
+        studies=pl.col("professional_occupation") == "student",
+        has_license=pl.col("has_driving_license").eq("yes")
+        | pl.col("has_motorcycle_driving_license").eq("yes"),
+        has_pt_subscription="has_public_transit_subscription",
+        number_of_trips="nb_trips",
+        person_weight="sample_weight_all",
+        trip_weight="sample_weight_surveyed",
+        socioprofessional_class=pl.col("pcs_group_code").fill_null(8),
+    )
+
+    trip_columns = {
+        "trip_id": "trip_id",
+        "person_id": "person_id",
+        # Convert departure / arrival time from minutes to seconds.
+        "departure_time": pl.col("departure_time").cast(pl.UInt32) * 60,
+        "arrival_time": pl.col("arrival_time").cast(pl.UInt32) * 60,
+        "trip_duration": pl.col("travel_time").cast(pl.UInt32) * 60,
+        "activity_duration": pl.col("destination_activity_duration").cast(pl.UInt32) * 60,
+        "preceding_purpose": "origin_purpose_group",
+        "following_purpose": "destination_purpose_group",
+        "is_first_trip": "first_trip",
+        "is_last_trip": "last_trip",
+        "mode": "main_mode_group",
+        "origin_departement_id": "origin_dep",
+        "destination_departement_id": "destination_dep",
+    }
+    # Columns euclidean_distance and routed_distance are only added if they have no NULL values.
+    if std_survey.trips["trip_euclidean_distance_km"].is_not_null().all():
+        trip_columns["euclidean_distance"] = "trip_euclidean_distance_km"
+    if std_survey.trips["trip_travel_distance_km"].is_not_null().all():
+        trip_columns["routed_distance"] = "trip_travel_distance_km"
+    df_trips = std_survey.trips.select(**trip_columns)
+
+    # Add households consumption units (1 for 1st person, +0.5 for any other person 14+, +0.3 for
+    # any other person below 14.
+    # When age is NULL, it is assumed to be over 14.
+    cons_units = (
+        df_persons.with_columns(over_14=pl.col("age").ge(14).fill_null(True))
+        .group_by("household_id")
+        .agg(
+            consumption_units=1.0
+            + pl.max_horizontal(0, pl.col("over_14").sum() - 1) * 0.5
+            + pl.col("over_14").not_().sum() * 0.3
+        )
+    )
+    df_households = df_households.join(cons_units, on="household_id", how="left")
+
+    # Add home département to persons.
+    df_persons = df_persons.join(
+        df_households.select("household_id", "departement_id"), on="household_id", how="left"
+    )
+    # Flag persons with at least one trip as car passenger.
+    df_persons = df_persons.with_columns(
+        is_passenger=pl.col("person_id").is_in(
+            df_trips.filter(mode="car_passenger")["person_id"].to_list()
+        )
+    )
+    # Add `trip_weight` to trips.
+    df_trips = df_trips.join(
+        df_persons.select("person_id", "trip_weight"), on="person_id", how="left"
+    )
+
+    # Impute urban type.
+    if context.config("use_urban_type"):
+        df_urban_type = context.stage("data.spatial.urban_type")[["commune_id", "urban_type"]]
+
+        # Add commune_id to persons.
+        df_persons = df_persons.join(
+            std_survey.households.select("household_id", commune_id="home_insee"),
+            on="household_id",
+            how="left",
+        )
+        # Add urban_type to persons.
+        df_persons = df_persons.join(df_urban_type, on="commune_id", how="left")
+        df_persons = df_persons.with_columns(pl.col("urban_type").fill_null(pl.lit("none"))).drop(
+            "commune_id"
+        )
+
+    return df_households, df_persons, df_trips

--- a/data/hts/mobisurvstd/filtered.py
+++ b/data/hts/mobisurvstd/filtered.py
@@ -1,0 +1,70 @@
+import polars as pl
+
+import data.hts.hts as hts
+
+"""
+This stage filters out observations which live or travel outside of the study area.
+"""
+
+
+def configure(context):
+    context.stage("data.hts.mobisurvstd.cleaned")
+    context.stage("data.spatial.codes")
+    context.config("filter_hts", True)
+
+
+def execute(context):
+    df_households, df_persons, df_trips = context.stage("data.hts.mobisurvstd.cleaned")
+
+    remove_ids = set()
+
+    # Remove persons for which at least 1 trip has NULL departure or arrival time.
+    remove_ids |= set(
+        df_trips.filter(pl.col("departure_time").is_null() | pl.col("arrival_time").is_null())[
+            "person_id"
+        ]
+    )
+
+    # Remove persons for which at least 1 trip has NULL origin or destination purpose.
+    remove_ids |= set(
+        df_trips.filter(
+            pl.col("preceding_purpose").is_null() | pl.col("following_purpose").is_null()
+        )["person_id"]
+    )
+
+    # Remove persons for which at least 1 trip has different origin purpose than destination purpose
+    # of the previous trip.
+    remove_ids |= set(
+        df_trips.filter(
+            pl.col("preceding_purpose").ne(pl.col("following_purpose").shift(1).over("person_id"))
+        )["person_id"]
+    )
+
+    if context.config("filter_hts"):
+        df_codes = context.stage("data.spatial.codes")
+        # Filter for non-residents
+        requested_departments = df_codes["departement_id"].astype(str).unique()
+        df_persons = df_persons.filter(pl.col("departement_id").is_in(requested_departments))
+
+        # Filter trips outside the area.
+        remove_ids |= set(
+            df_trips.filter(
+                pl.col("origin_departement_id").is_in(requested_departments).not_()
+                | pl.col("destination_departement_id").is_in(requested_departments).not_()
+            )["person_id"]
+        )
+
+    print("Nb persons: {}".format(len(df_persons)))
+    # Keep only persons with all their trips and households with at least one remaining person.
+    df_persons = df_persons.filter(pl.col("person_id").is_in(remove_ids).not_())
+    df_trips = df_trips.filter(pl.col("person_id").is_in(remove_ids).not_())
+    df_households = df_households.join(df_persons, on="household_id", how="semi")
+    print("Nb persons: {}".format(len(df_persons)))
+
+    df_households_pd = df_households.to_pandas()
+    df_persons_pd = df_persons.to_pandas()
+    df_trips_pd = df_trips.to_pandas()
+
+    hts.check(df_households_pd, df_persons_pd, df_trips_pd)
+
+    return df_households_pd, df_persons_pd, df_trips_pd

--- a/data/hts/mobisurvstd/raw.py
+++ b/data/hts/mobisurvstd/raw.py
@@ -1,0 +1,24 @@
+import mobisurvstd
+
+"""
+This stage standardize the input HTS to the MobiSurvStd format.
+"""
+
+
+def configure(context):
+    context.config("mobisurvstd.path")
+
+
+def execute(context):
+    std_survey = mobisurvstd.standardize(
+        source=context.config("mobisurvstd.path"), output_directory=None, skip_spatial=True
+    )
+    return std_survey
+
+
+def validate(context):
+    survey_type = mobisurvstd.utils.guess_survey_type(context.config("mobisurvstd.path"))
+    if survey_type is None:
+        raise RuntimeError(
+            "Cannot read HTS survey from: `{}`".format(context.config("mobisurvstd.path"))
+        )

--- a/data/hts/mobisurvstd/raw.py
+++ b/data/hts/mobisurvstd/raw.py
@@ -1,3 +1,5 @@
+import os
+
 import mobisurvstd
 
 """
@@ -13,12 +15,11 @@ def execute(context):
     std_survey = mobisurvstd.standardize(
         source=context.config("mobisurvstd.path"), output_directory=None, skip_spatial=True
     )
+    if std_survey is None:
+        raise RuntimeError("The HTS survey could not be imported by MobiSurvStd")
     return std_survey
 
 
 def validate(context):
-    survey_type = mobisurvstd.utils.guess_survey_type(context.config("mobisurvstd.path"))
-    if survey_type is None:
-        raise RuntimeError(
-            "Cannot read HTS survey from: `{}`".format(context.config("mobisurvstd.path"))
-        )
+    path = context.config("mobisurvstd.path")
+    assert os.path.isfile(path) or os.path.isdir(path), f"Cannot read HTS survey from `{path}`"

--- a/data/hts/selected.py
+++ b/data/hts/selected.py
@@ -1,10 +1,9 @@
-import pandas as pd
-import numpy as np
-
 def configure(context):
     hts = context.config("hts")
 
-    if hts == "egt":
+    if hts == "mobisurvstd":
+        context.stage("data.hts.mobisurvstd.filtered", alias = "hts")
+    elif hts == "egt":
         context.stage("data.hts.egt.filtered", alias = "hts")
     elif hts == "entd":
         context.stage("data.hts.entd.reweighted", alias = "hts")

--- a/environment.yml
+++ b/environment.yml
@@ -20,14 +20,16 @@ dependencies:
   - pip=23.0.1
   - python=3.10.16
   - python-calamine=0.3.1
-  - py7zr=0.20.8
+  - py7zr=0.22.0
   - pytest=7.2.2
   - xlwt=1.3.0
   - sqlite=3.49.1
   - mock=5.1.0
   - pyarrow=19.0.1
+  - polars=1.31.0
 
   - pip:
     - synpp==1.6.0
     - bhepop2==2.0.1
     - osmium==4.0.2
+    - mobisurvstd==0.5.0

--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
     - synpp==1.6.0
     - bhepop2==2.0.1
     - osmium==4.0.2
-    - mobisurvstd==0.5.0
+    - mobisurvstd==0.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - pip=23.0.1
   - python=3.10.16
   - python-calamine=0.3.1
-  - py7zr=0.22.0
+  - py7zr=0.20.8
   - pytest=7.2.2
   - xlwt=1.3.0
   - sqlite=3.49.1


### PR DESCRIPTION
Hello.

This PR adds the option to use [MobiSurvStd](https://mobisurvstd.github.io/MobiSurvStd/) to import household travel surveys (HTS).

This means that any HTS supported by MobiSurvStd (80 as of today) can be used in eqasim without having to modify the code.

To use MobiSurvStd, the following config needs to be used (for EMP 2019 as an example):

```yaml
config:
  hts: mobisurvstd

  mobisurvstd:
    path: data/emp_2019/emp_2019_donnees_individuelles_anonymisees_novembre2024.zip
```

I did not change anything to the documentation. It would be great if 2-3 persons could test it to check if everything works as expected (maybe @Nitnelav on Lyon?) before making it "official".

There are a few things to consider:

- The path provided can be either a zipfile or a directory where the survey data is stored.
- MobiSurvStd will detect automatically the survey type.
- I tested the import with EMP 2019 and EGT 2010. It works fine and the resulting DataFrames are almost identical to the ones resulting from the dedicated implementations (except for a few differences, see below).
- I tested successfully the import and population generation for Chambéry EMC2.
- ENTD is not yet supported by MobiSurvStd so EMP should be the new "national" survey.
- The original household / person / trip id is not provided. It is available in MobiSurvStd but it uses the Struct datatype which is poorly supported by pandas and CSV. I saw that the EGT and Lyon implementations provided the `egt_household_id` and `edgt_household_id` variables but I don't think that they are really used.
- I did not provide the `income_class` variable. I did not understand how the variable can be used given that the lower bounds / upper bounds of the classes can vary from survey to survey. Note that MobiSurvStd provides the `income_lower_bound` and `income_upper_bound` variables if needed, although there are only available for EGT 2010 and EGT 2020 so it is of limited use.
- Do we want to keep all surveyed persons or only those who were asked whether they traveled during the previous day?
- For purpose, MobiSurvStd distinguishes between "task", "escort", and "other", while eqasim only allows "other". For now, I replace "task" and "escort" with "other" but I do think that "escort" activities are peculiar and should be modeled differently at some point.
- For modes, there are a few differences between MobiSurvStd and eqasim. I saw that eqasim replace motorcycle by car and any "undefined" mode (airplane, water transport, NULL values) by public transit. The PR applies that same rules to the MobiSurvStd output (with minor differences like motorcycle passengers being replaced by car and not car passenger). I think that the "undefined" modes should be treated differently however (dropping the persons? keeping them as special trips so they can be dropped off prior to running the transport simulator?).
- Is it okay how I define the config? Should I remove the `data/` part of the `path` and concatenate with the config `data_path` variable?
- MobiSurvStd uses `loguru` to log info, warning, error messages. It looks a bit odd next to synpp logging but it is only a visual difference so it is fine.
- I noticed that the EGT 2010 format has changed in the last year. The new format available on [Progedo](https://data.progedo.fr/studies/doi/10.13144/lil-0883) is not compatible with eqasim and MobiSurvStd is not compatible with the old format. MobiSurvStd could be updated to be compatible with both formats.
- There is a difference in the number of bikes per household for EMP 2019 compared to the current code because MobiSurvStd also count children bikes.
- There is a difference in the `consumption_units` of the households for EMP 2019 because age is unknown for most of the persons (only 1 person per household is really surveyed). The current code implementation assumes that all persons with unknown age are below 14, while I assumed that they are above 14.
- Is the `urban_type` variable really used for something? I saw that it was specified at the household level for EMP and at the person level for EGT. In my implementation it is computed at the person level but it is not available for EMP (because the home insee is unknown and MobiSurvStd does not read the actual home urban type variable).
- Unknown values for `employed`, `studies`, `has_license`, `has_pt_subscription` should be False or NULL? I saw that the existing hts codes seem to set them to False but I kept them as NULL.
- Should Euclidean / routed distance be set in kilometers or meters? I think that meters are used for EGT and kilometers for the other surveys.

Finally, I think that this PR could lead to the addition of new variables to the pipeline. There are quite a few variables that MobiSurvStd reads and standardizes and that could be useful to have in the synthetic population (e.g. : education level, whether the person is only working at home). [This table](https://mobisurvstd.github.io/MobiSurvStd/table.html) lists all the variables available. The ones in bold are available in all surveys so they should be prioritised.