### PR TITLE
feat: use parquet format for SIRENE data

### DIFF
--- a/data/sirene/raw_siren.py
+++ b/data/sirene/raw_siren.py
@@ -1,45 +1,33 @@
 import os
-import pandas as pd
+import polars as pl
 
 """
 This stage loads the raw data from the French enterprise registry.
 """
 
+
 def configure(context):
     context.config("data_path")
-    context.config("siren_path", "sirene/StockUniteLegale_utf8.zip")
+    context.config("siren_path", "sirene/StockUniteLegale_utf8.parquet")
 
     context.stage("data.sirene.raw_siret")
 
+
 def execute(context):
-    relevant_siren = context.stage("data.sirene.raw_siret")["siren"].unique()
-    df_siren = []
+    relevant_siren = pl.from_pandas(context.stage("data.sirene.raw_siret"))
 
+    filename = os.path.join(context.config("data_path"), context.config("siren_path"))
+    df_siren = (
+        pl.scan_parquet(filename)
+        .join(relevant_siren.lazy(), on="siren", how="semi")
+        .select("siren", "categorieJuridiqueUniteLegale")
+        .collect()
+    )
+    return df_siren.to_pandas()
 
-
-    COLUMNS_DTYPES = {
-        "siren":"int32", 
-        "categorieJuridiqueUniteLegale":"str", 
-    }
-    
-    with context.progress(label = "Reading SIREN...") as progress:
-        csv = pd.read_csv("%s/%s" % (context.config("data_path"), context.config("siren_path")),
-              usecols = COLUMNS_DTYPES.keys(), dtype = COLUMNS_DTYPES,chunksize = 10240)
-
-        for df_chunk in csv:
-            progress.update(len(df_chunk))
-
-            df_chunk = df_chunk[
-                df_chunk["siren"].isin(relevant_siren)
-            ]
-
-            if len(df_chunk) > 0:
-                df_siren.append(df_chunk)
-
-    return pd.concat(df_siren)
 
 def validate(context):
-    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("siren_path"))):
+    filename = os.path.join(context.config("data_path"), context.config("siren_path"))
+    if not os.path.isfile(filename):
         raise RuntimeError("SIRENE: SIREN data is not available")
-
-    return os.path.getsize("%s/%s" % (context.config("data_path"), context.config("siren_path")))
+    return os.path.getsize(filename)

--- a/data/sirene/raw_siret.py
+++ b/data/sirene/raw_siret.py
@@ -1,56 +1,50 @@
 import os
-import pandas as pd
+import polars as pl
 
 """
 This stage loads the raw data from the French enterprise registry.
 """
 
+
 def configure(context):
     context.config("data_path")
-    context.config("siret_path", "sirene/StockEtablissement_utf8.zip")
+    context.config("siret_path", "sirene/StockEtablissement_utf8.parquet")
 
     context.stage("data.spatial.codes")
+
 
 def execute(context):
     # Filter by departement
     df_codes = context.stage("data.spatial.codes")
     requested_departements = set(df_codes["departement_id"].unique())
 
-    df_siret = []
+    filename = os.path.join(context.config("data_path"), context.config("siret_path"))
+    lf = pl.scan_parquet(filename)
+    lf = lf.filter(pl.col("codeCommuneEtablissement").is_not_null())
+    # The departement code can be read from the 2 first characters of the INSEE commune code, or
+    # from the 3 first characters for oversea departements (e.g., Fort-de-France: 972).
+    deps2 = {dep for dep in requested_departements if len(dep) == 2}
+    deps3 = {dep for dep in requested_departements if len(dep) == 3}
+    assert len(deps2) + len(deps3) == len(requested_departements)
+    if deps2:
+        lf = lf.filter(pl.col("codeCommuneEtablissement").str.slice(0, 2).is_in(deps2))
+    if deps3:
+        lf = lf.filter(pl.col("codeCommuneEtablissement").str.slice(0, 3).is_in(deps3))
 
+    df_siret = lf.select(
+        "siren",
+        "siret",
+        "codeCommuneEtablissement",
+        "activitePrincipaleEtablissement",
+        "trancheEffectifsEtablissement",
+        "etatAdministratifEtablissement",
+    ).collect()
 
-    COLUMNS_DTYPES = {
-        "siren":"int32", 
-        "siret":"int64", 
-        "codeCommuneEtablissement":"str",
-        "activitePrincipaleEtablissement":"str", 
-        "trancheEffectifsEtablissement":"str",
-        "etatAdministratifEtablissement":"str"
-    }
-    
-    with context.progress(label = "Reading SIRET...") as progress:
-        csv = pd.read_csv("%s/%s" % (context.config("data_path"), context.config("siret_path")),
-                          usecols = COLUMNS_DTYPES.keys(), dtype = COLUMNS_DTYPES,chunksize = 10240)
+    return df_siret.to_pandas()
 
-        for df_chunk in csv:
-            progress.update(len(df_chunk))
-
-            f = df_chunk["codeCommuneEtablissement"].isna() # Just to get a mask
-
-            for departement in requested_departements:
-                f |= df_chunk["codeCommuneEtablissement"].str.startswith(departement)
-
-            f &= ~df_chunk["codeCommuneEtablissement"].isna()
-            df_chunk = df_chunk[f]
-
-            if len(df_chunk) > 0:
-                df_siret.append(df_chunk)
-
-
-    return pd.concat(df_siret)
 
 def validate(context):
-    if not os.path.exists("%s/%s" % (context.config("data_path"), context.config("siret_path"))):
+    filename = os.path.join(context.config("data_path"), context.config("siret_path"))
+    if not os.path.isfile(filename):
         raise RuntimeError("SIRENE: SIRET data is not available")
-
-    return os.path.getsize("%s/%s" % (context.config("data_path"), context.config("siret_path")))
+    return os.path.getsize(filename)

--- a/docs/population/population_data.md
+++ b/docs/population/population_data.md
@@ -108,19 +108,22 @@ The enterprise census of France is available on data.gouv.fr:
 
 - [Enterprise census](https://www.data.gouv.fr/fr/datasets/base-sirene-des-entreprises-et-de-leurs-etablissements-siren-siret/)
 - Scroll down and click on the blue download button on the right for the two following data sets:
-  - **Sirene : Fichier StockUniteLegale** (followed by a date), the database of enterprises
-  - **Sirene : Fichier StockEtablissement** (followed by a date), the database of enterprise facilities
+  - **Sirene : Fichier StockUniteLegale du dd mm yyyy (format parquet)** (where "dd mm yyyy" is the
+    date), the database of enterprises
+  - **Sirene : Fichier StockEtablissement du dd mm yyy (format parquet)** (where "dd mm yyyy" is the
+    date), the database of enterprise facilities
 - The files are updated monthly and are rather large. After downloading, you should have two files:
-  - `StockEtablissement_utf8.zip`
-  - `StockUniteLegale_utf8.zip`
-- Move both *zip* files into `data/sirene`.
+  - `StockEtablissement_utf8.parquet`
+  - `StockUniteLegale_utf8.parquet`
+- Move both *parquet* files into `data/sirene`.
 
 The geolocated enterprise census is available on data.gouv.fr:
 
 - [Geolocated enterprise census](https://www.data.gouv.fr/fr/datasets/geolocalisation-des-etablissements-du-repertoire-sirene-pour-les-etudes-statistiques/)
 - Scroll down and click on the blue download button on the right for the following data set:
-    - **Sirene : Fichier GeolocalisationEtablissement_Sirene_pour_etudes_statistiques** (followed by a date), 
-- Put the downloaded *zip* file into `data/sirene`
+    - **Sirene : Fichier GeolocalisationEtablissement_Sirene_pour_etudes_statistiques du dd mm yyyy
+      (format parquet)** (where "dd mm yyyy" is the date)
+- Put the downloaded *parquet* file into `data/sirene`
 
 ## 10) Buildings database (BD TOPO)
 


### PR DESCRIPTION
This PR changes the format used to read SIRENE data from zipped CSVs to Parquet files.

That was actually faster to do than waiting 1 hour for the files to be imported. :)

It works for the 3 SIRENE files (SIREN, SIRET, and Geoloc). Note that I used polars `scan_parquet` to apply the filters without having to read the whole files (they cannot fit in memory). I hope that you are fine with that. The polars DataFrames are converted to pandas DataFrames just after reading the files. An alternative would be read them in chunks with pandas but that would be slower.

For Île-de-France, the reading time for the 3 files went from about 1 hour to under a minute.

The PR solves partly #345. Note that switching to parquet can bring huge benefits to running time but not to disk use (parquet files are not significantly smaller than zipped CSVs).

The documentation is updated accordingly.